### PR TITLE
fix: replace memcache with memcached

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ The following are the known incompatibilities with tilestache configurations:
     * No `dirs` parameter - Files are currently stored in a flat structure rather than creating separate directories
     * No `gzip` parameter - Might be added in the future
     * The `path` parameter must be supplied as a file path, not a URI
-* Memcache cache:
+* Memcached cache:
+    * The `name` parameter should be `memcached` not `memcache` (note the "d" at the end)
     * No `revision` parameter - Put the revision inside the key prefix
     * The `key prefix` parameter is replaced with `keyprefix`
     * The `servers` array is now an array of objects containing `host` and `port` instead of an array of strings with those combined

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,19 +114,19 @@ Example:
 }
 ```
 
-### Memcache
+### Memcached
 
-Cache tiles using memcache.
+Cache tiles using memcached.
 
-Name should be "memcache"
+Name should be "memcached"
 
 Configuration options:
 
 | Parameter | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| host | String | No | 127.0.0.1 | The host of the memcache server. A convenience equivalent to supplying `servers` with a single entry. Do not supply both this and `servers` |
-| port | int | No | 6379 | The port of the memcache server. A convenience equivalent to supplying `servers` with a single entry. Do not supply both this and `servers` |
-| keyprefix | string | No | None | A prefix to use for keys stored in cache. Helps avoid collisions when multiple applications use the same memcache |
+| host | String | No | 127.0.0.1 | The host of the memcached server. A convenience equivalent to supplying `servers` with a single entry. Do not supply both this and `servers` |
+| port | int | No | 6379 | The port of the memcached server. A convenience equivalent to supplying `servers` with a single entry. Do not supply both this and `servers` |
+| keyprefix | string | No | None | A prefix to use for keys stored in cache. Helps avoid collisions when multiple applications use the same memcached |
 | ttl | uint32 | No | 1 day | How long cache entries should persist for in seconds. Cannot be disabled. |
 | servers | Array of `host` and `port` | No | host and port | The list of servers to connect to supplied as an array of objects, each with a host and key parameter. This should only have a single entry when operating in standalone mode. If this is unspecified it uses the standalone `host` and `port` parameters as a default, therefore this shouldn't be specified at the same time as those |
 
@@ -134,7 +134,7 @@ Example:
 
 ```yaml
 cache:
-  name: memcache
+  name: memcached
   host: 127.0.0.1
   port: 11211
 ```

--- a/examples/configurations/two_tier_cache.yml
+++ b/examples/configurations/two_tier_cache.yml
@@ -1,7 +1,7 @@
 cache:
   name: multi
   tiers:
-    - name: memcache
+    - name: memcached
       maxsize: 1000
       ttl: 1000
     - name: s3

--- a/internal/caches/cache.go
+++ b/internal/caches/cache.go
@@ -78,13 +78,13 @@ func ConstructCache(rawConfig map[string]interface{}, errorMessages *config.Erro
 			return nil, err
 		}
 		return ConstructRedis(&config, errorMessages)
-	} else if rawConfig["name"] == "memcache" {
-		var config MemcacheConfig
+	} else if rawConfig["name"] == "memcached" {
+		var config MemcachedConfig
 		err := mapstructure.Decode(rawConfig, &config)
 		if err != nil {
 			return nil, err
 		}
-		return ConstructMemcache(&config, errorMessages)
+		return ConstructMemcached(&config, errorMessages)
 	}
 
 	name := fmt.Sprintf("%#v", rawConfig["name"])

--- a/internal/caches/memcached_test.go
+++ b/internal/caches/memcached_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func setupMemcacheContainer(ctx context.Context, t *testing.T) (testcontainers.Container, func(t *testing.T)) {
+func setupMemcachedContainer(ctx context.Context, t *testing.T) (testcontainers.Container, func(t *testing.T)) {
 	t.Log("setup container")
 
 	req := testcontainers.ContainerRequest{
@@ -31,7 +31,7 @@ func setupMemcacheContainer(ctx context.Context, t *testing.T) (testcontainers.C
 		ExposedPorts: []string{"11211/tcp"},
 		WaitingFor:   wait.ForExposedPort(),
 	}
-	memcacheC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	memcachedC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
@@ -39,90 +39,90 @@ func setupMemcacheContainer(ctx context.Context, t *testing.T) (testcontainers.C
 		return nil, nil
 	}
 
-	return memcacheC, func(t *testing.T) {
+	return memcachedC, func(t *testing.T) {
 		t.Log("teardown container")
 
-		err := memcacheC.Terminate(ctx)
+		err := memcachedC.Terminate(ctx)
 		assert.Nil(t, err)
 	}
 }
 
-func TestMemcacheWithContainerHostAndPort(t *testing.T) {
+func TestMemcachedWithContainerHostAndPort(t *testing.T) {
 	ctx := context.Background()
-	memcacheC, cleanupF := setupMemcacheContainer(ctx, t)
-	if !assert.NotNil(t, memcacheC) {
+	memcachedC, cleanupF := setupMemcachedContainer(ctx, t)
+	if !assert.NotNil(t, memcachedC) {
 		return
 	}
 
 	defer cleanupF(t)
 
-	endpoint, err := memcacheC.Endpoint(ctx, "")
+	endpoint, err := memcachedC.Endpoint(ctx, "")
 	if !assert.Nil(t, err) {
 		return
 	}
 
-	config := MemcacheConfig{
+	config := MemcachedConfig{
 		HostAndPort: extractHostAndPort(t, endpoint),
 	}
 
-	r, err := ConstructMemcache(&config, nil)
+	r, err := ConstructMemcached(&config, nil)
 	_ = assert.Nil(t, err) &&
 		validateSaveAndLookup(t, r)
 }
 
-func TestMemcacheWithContainerSingleServersArr(t *testing.T) {
+func TestMemcachedWithContainerSingleServersArr(t *testing.T) {
 	ctx := context.Background()
-	memcacheC, cleanupF := setupMemcacheContainer(ctx, t)
-	if !assert.NotNil(t, memcacheC) {
+	memcachedC, cleanupF := setupMemcachedContainer(ctx, t)
+	if !assert.NotNil(t, memcachedC) {
 		return
 	}
 
 	defer cleanupF(t)
 
-	endpoint, err := memcacheC.Endpoint(ctx, "")
+	endpoint, err := memcachedC.Endpoint(ctx, "")
 	if !assert.Nil(t, err) {
 		return
 	}
 
-	config := MemcacheConfig{
+	config := MemcachedConfig{
 		Servers: []HostAndPort{extractHostAndPort(t, endpoint)},
 	}
 
-	r, err := ConstructMemcache(&config, nil)
+	r, err := ConstructMemcached(&config, nil)
 	_ = assert.Nil(t, err) &&
 		validateSaveAndLookup(t, r)
 }
 
-func TestMemcacheWithContainerDiffPrefix(t *testing.T) {
+func TestMemcachedWithContainerDiffPrefix(t *testing.T) {
 	ctx := context.Background()
-	memcacheC, cleanupF := setupMemcacheContainer(ctx, t)
-	if !assert.NotNil(t, memcacheC) {
+	memcachedC, cleanupF := setupMemcachedContainer(ctx, t)
+	if !assert.NotNil(t, memcachedC) {
 		return
 	}
 
 	defer cleanupF(t)
 
-	endpoint, err := memcacheC.Endpoint(ctx, "")
+	endpoint, err := memcachedC.Endpoint(ctx, "")
 	if !assert.Nil(t, err) {
 		return
 	}
 
-	config := MemcacheConfig{
+	config := MemcachedConfig{
 		HostAndPort: extractHostAndPort(t, endpoint),
 		KeyPrefix:   "first_",
 	}
 
-	r, err := ConstructMemcache(&config, nil)
+	r, err := ConstructMemcached(&config, nil)
 	if !assert.Nil(t, err) {
 		return
 	}
 
-	config2 := MemcacheConfig{
+	config2 := MemcachedConfig{
 		HostAndPort: extractHostAndPort(t, endpoint),
 		KeyPrefix:   "second_",
 	}
 
-	r2, err := ConstructMemcache(&config2, nil)
+	r2, err := ConstructMemcached(&config2, nil)
 	_ = assert.Nil(t, err) &&
 		validateSaveAndLookup(t, r) &&
 		validateSaveAndLookup(t, r2)


### PR DESCRIPTION
Memcached is the proper cache system.  Memcache is used to refer to client libraries that talk to Memcached.  There's historic confusion because 15 years ago there were both memcache and memcached PHP modules for it.  Nowadays it's commonly called memcache even though its official name is memcached.  Everywhere else it's normal to refer to the name of the DB system, not the driver we use to talk to it, so that'd suggest it should be memcached.

I'm torn.

@cognusion I could use an opinion.