### PR TITLE
Support TLS including Let's Encrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ disk_tile_cache/
 tilegroxy
 test_config.yml
 .env
+
+certs/
+
+*.log

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Tilegroxy shines when you consume maps from multiple sources.  It isn't tied to 
 * Generic support for any content type (raster or vector)
 * Configurable timeout, logging, and error handling rules
 * Commands for seeding and testing your layers
+* Run as HTTPS including Let's Encrypt support
 * Container deployment
 
 The following are on the roadmap and expected before a 1.0 release:
@@ -34,7 +35,6 @@ The following are on the roadmap and expected before a 1.0 release:
 * Providers that composite/modify vector layers formats such as [MVT](https://github.com/mapbox/vector-tile-spec) or tiled GeoJSON
 * OpenTelemetry support
 * Support for external secret stores such as AWS Secrets Manager to avoid secrets in the configuration
-* Support for HTTPS server w/ Let's Encrypt or static certs
 
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -622,6 +622,7 @@ Configuration options:
 | Production | bool | No | false | Hardens operation for usage in production. For instance, controls serving splash page, documentation, x-powered-by header. |
 | Timeout | uint | No | 60 | How long (in seconds) a request can be in flight before we cancel it and return an error |
 | Gzip | bool | No | false | Whether to gzip compress HTTP responses |
+| Encrypt | [Encryption](#encryption) | No | None | Configuration for enabling TLS (HTTPS). Don't specify to operate without encryption (the default) |
 
 The following can be supplied as environment variables:
 
@@ -634,6 +635,36 @@ The following can be supplied as environment variables:
 | Production | SERVER_PRODUCTION | 
 | Timeout | SERVER_TIMEOUT |
 | Gzip | SERVER_GZIP |
+
+### Encryption
+
+Configures how encryption should be applied to the server.  
+
+There are two main ways this can work:
+1. With a pre-supplied certificate and keyfile
+2. Via [Let's Encrypt](https://letsencrypt.org/how-it-works/) (ACME) using Go's built-in autocert module
+
+If a certificate and keyfile are supplied the server will utilize option 1, otherwise it'll fallback to option 2. If you don't want to utilize encryption (for example you have TLS termination handled externally) simply omit `Server.Encrypt`
+
+Configuration options:
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| Domain | string | Yes | None | The domain name you're operating with (the domain end-users use) |
+| Cache | string | No | ./certs | The path to a directory to cache certificates in if using let's encrypt. 
+| Certificate | string | None | The file path to the TLS certificate
+| KeyFile | string | None | The file path to the keyfile
+| HttpPort | int | No | None |The port used for non-encrypted traffic. Required if using Let's Encrypt to provide for the ACME challenge, in which case this needs to indirectly be 80 (that is, this can be set to e.g. 8080 if something ahead of this redirects 80 to 8080). Everything except .well-known will be redirected to the main port when set. |
+
+The following can be supplied as environment variables:
+
+| Configuration Parameter | Environment Variable |
+| --- | --- |
+| Domain | SERVER_ENCRYPT_DOMAIN |
+| Cache | SERVER_ENCRYPT_CACHE | 
+| Certificate | SERVER_ENCRYPT_CERTIFICATE | 
+| KeyFile | SERVER_ENCRYPT_KEYFILE | 
+| HttpPort | SERVER_ENCRYPT_HTTPPORT | 
 
 
 ## Client

--- a/examples/configurations/prod.yml
+++ b/examples/configurations/prod.yml
@@ -1,0 +1,52 @@
+Server:
+    BindHost: 0.0.0.0
+    Gzip: true
+    Port: 8443
+    Production: true
+    Headers:
+        Access-Control-Allow-Origin: "*"
+    Timeout: 30
+    Encrypt:
+      Domain: dev.local.io
+      Certificate: certs/dev.local.io.crt
+      Keyfile: certs/dev.local.io.key
+Logging:
+    Access:
+        Console: false
+        Format: combined
+        Path: "my-access.log"
+    Main:
+        Console: true
+        Format: json
+        Level: error
+        Path: "my-main.log"
+# Authentication:
+#   name: jwt
+#   algorithm: HS256
+#   key: some_secret_key
+Client:
+    UnknownLength: false
+    ContentTypes:
+        - image/png
+        - image/jpeg
+        - image/webp
+    StatusCodes:
+        - 200
+        - 201
+    MaxLength: 100000000
+    UserAgent: company/1.0
+error:
+    Mode: image
+cache:
+  name: multi
+  tiers:
+    - name: memory
+      maxsize: 1000
+      ttl: 1000
+    - name: disk
+      path: "./disk_tile_cache"
+layers: 
+  - id: osm
+    provider:
+        name: proxy
+        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type EncryptionConfig struct {
 	Cache       string //The path to a directory to cache certificates in if using let's encrypt. Defaults to ./certs
 	Certificate string //The file path to get to the TLS certificate
 	KeyFile     string //The file path to get to the keyfile
+	HttpPort    int    //The port used for non-encrypted traffic. Required if using Let's Encrypt for ACME challenge and needs to indirectly be 80 (that is, it could be 8080 if something else redirects 80 to 8080). Everything except .well-known will be redirected to the main port when set.
 }
 
 type ServerConfig struct {
@@ -87,6 +88,7 @@ const (
 // replaced with fully static constants later if it does turn out nobody ever sees value in it
 type ErrorMessages struct {
 	NotAuthorized           string
+	ParamRequired           string
 	InvalidParam            string
 	RangeError              string
 	ServerError             string
@@ -224,6 +226,7 @@ func DefaultConfig() Config {
 				ScriptError:             "The script specified for %v is invalid: %v",
 				OneOfRequired:           "You must specify one of: %v",
 				Timeout:                 "Timeout error",
+				ParamRequired:           "Parameter %v is required",
 			},
 			Images: ErrorImages{
 				OutOfBounds:    images.KeyImageTransparent,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,16 @@ import (
 	_ "github.com/spf13/viper/remote"
 )
 
+// Configuration for TLS (HTTPS) operation. If this is configured then TLS is enabled. This can operate either with a static certificate and keyfile via the filesystem or via ACME/Let's Encrypt
+type EncryptionConfig struct {
+	Domain      string //The domain name you're operating with (the domain end-users use). Required
+	Cache       string //The path to a directory to cache certificates in if using let's encrypt. Defaults to ./certs
+	Certificate string //The file path to get to the TLS certificate
+	KeyFile     string //The file path to get to the keyfile
+}
+
 type ServerConfig struct {
+	Encrypt    *EncryptionConfig //Whether and how to use TLS. Defaults to none AKA no encryption.
 	BindHost   string            //IP address to bind HTTP server to
 	Port       int               //Port to bind HTTP server to
 	RootPath   string            //Root HTTP Path to apply to all endpoints. Defaults to /

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -322,7 +322,16 @@ func ListenAndServe(config *config.Config, layerGroup *layers.LayerGroup, auth a
 		}()
 
 		slog.InfoContext(context.Background(), "Binding...")
-		srvErr <- srv.ListenAndServe()
+
+		if config.Server.Encrypt != nil {
+			if config.Server.Encrypt.Certificate != "" && config.Server.Encrypt.KeyFile != "" {
+				srvErr <- srv.ListenAndServeTLS(config.Server.Encrypt.Certificate, config.Server.Encrypt.KeyFile)
+			} else {
+				//TODO: Let's Encrypt
+			}
+		} else {
+			srvErr <- srv.ListenAndServe()
+		}
 	}()
 
 	select {


### PR DESCRIPTION
Not sure how to properly test this...

I also added support for configuring TLS version and Ciphers but not sure I like how that came together...  I don't want to support weakening security settings and the only way to do what I want (allow explicitly disabling ciphers) isn't very maintainable as Go doesn't expose a way to get the default list of ciphers. Plus testing all that is non-trivial... without someone explicitly asking for  that functionality I think I'll just leave that code in a side branch.