### PR TITLE
Revert "security(actions): bump securego/gosec from 2.20.0 to 2.21.1"

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -114,7 +114,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@0ce4453ddd8cca1291d2056cf903b545baad95a0 # v2.21.1
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # v2.20.0
         with:
           args: '-no-fail -exclude=G504 -fmt sarif -out results.sarif ./...'
       - name: Upload SARIF file


### PR DESCRIPTION
This reverts commit ffdfcb092eb7d50bdd235b8bf6d00b8fb01c3031 as new version of secgo action broke build. Seems revert in securego/gosec#1210 might have been incomplete as action still fails with error message indicating invalid sarif version of 2.2.0