### PR TITLE
ci: improve PR metrics comments

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -26,20 +26,56 @@ jobs:
         id: test
         run: |
           make clean cover
-          tail -1 coveragef.out | sed -E "s/[^0-9]*([0-9]+\.[0-9]*)%/VAL=\1/" >> $GITHUB_OUTPUT
+          VAL=$(tail -1 coveragef.out | sed -E "s/[^0-9]*([0-9]+\.[0-9]*)%/\1/")
+
+          OLD_VAL=$(curl "https://gist.githubusercontent.com/michad/d1b9e082f6608635494188d0f52bae69/raw/coverage.json" | jq '.message | rtrimstr("%") | tonumber')
+          
+          MSG="Code coverage"
+          if [ $(bc <<< "$VAL == $OLD_VAL") ]; then
+            MSG="$MSG is unchanged at $VAL%"
+          elif [ $(bc <<< "$VAL < $OLD_VAL") ]; then
+            MSG="$MSG decreased from $OLD_VAL% to $VAL%"
+          else
+            MSG="$MSG increased from $OLD_VAL% to $VAL%"
+          fi
+
+          echo "VAL=$VAL" >> $GITHUB_OUTPUT
+          echo "MSG=$MSG" >> $GITHUB_OUTPUT
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
         env:
-          VAL: ${{ steps.test.outputs.VAL }}
+          MSG: ${{ steps.test.outputs.MSG }}
         with:
           script: |
-            github.rest.issues.createComment({
+            let comments = (await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Code coverage is ' + process.env.VAL + '%'
-            })
+            })).data;
+            let id = null;                         
+            for(let i in comments) {
+              if(comments[i].user?.login == 'github-actions[bot]' && comments[i].body.startsWith("Code coverage ")){
+                id=comments[i].id;
+                break;
+              }
+            }
+            if(id !== null){
+              github.rest.issues.updateComment({
+                comment_id: id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.MSG
+              });
+              console.log("update comment " + id);
+            } else{
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.MSG
+              });
+            }
       - name: Create the Badge
         uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         if: github.event_name != 'pull_request'
@@ -72,20 +108,55 @@ jobs:
       - name: Run Test
         id: test
         run: |
-          make libyears | /usr/bin/jq '.libyear | .*100 | round/100' | xargs -I{} echo VAL={} >> $GITHUB_OUTPUT
+          VAL=$(make libyears | /usr/bin/jq '.libyear | .*100 | round/100')
+
+          OLD_VAL=$(curl "https://gist.githubusercontent.com/michad/d1b9e082f6608635494188d0f52bae69/raw/libyears.json" | jq '.message | rtrimstr(" years") | tonumber')
+          
+          MSG="Libyears"
+          if [ $(bc <<< "$VAL == $OLD_VAL") ]; then
+            MSG="$MSG is unchanged at $VAL"
+          elif [ $(bc <<< "$VAL < $OLD_VAL") ]; then
+            MSG="$MSG decreased from $OLD_VAL to $VAL"
+          else
+            MSG="$MSG increased from $OLD_VAL to $VAL"
+          fi
+
+          echo "VAL=$VAL" >> $GITHUB_OUTPUT
+          echo "MSG=$MSG" >> $GITHUB_OUTPUT
       - name: Comment on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
         env:
-          VAL: ${{ steps.test.outputs.VAL }}
+          MSG: ${{ steps.test.outputs.MSG }}
         with:
           script: |
-            github.rest.issues.createComment({
+            let comments = (await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Libyears is ' + process.env.VAL
-            })
+            })).data;
+            let id = null;                         
+            for(let i in comments) {                   
+              if(comments[i].user?.login == 'github-actions[bot]' && comments[i].body.startsWith("Libyears ")){
+                id=comments[i].id;
+                break;
+              }
+            }
+            if(id !== null){
+              github.rest.issues.updateComment({
+                comment_id: id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.MSG
+              });
+            } else{
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.MSG
+              })
+            }
       - name: Create the Badge
         uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         if: github.event_name != 'pull_request'

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -276,7 +276,7 @@ layers:
 
 	err = os.WriteFile(cfgFile, []byte(cfg2), 0600)
 	require.NoError(t, err)
-	time.Sleep(time.Second * 3) // Might need to rethink this static sleep if test flakiness occurs.  No way currently to hook into when reload finishes
+	time.Sleep(time.Second * 4) // Might need to rethink this static sleep if test flakiness occurs.  No way currently to hook into when reload finishes
 
 	req, err := http.NewRequest(http.MethodGet, "http://localhost:12343/tiles/color/8/12/32", nil)
 	require.NoError(t, err)
@@ -297,7 +297,7 @@ layers:
 	// Test that it keeps running on old config when given a broken config file to reload
 	err = os.WriteFile(cfgFile, []byte(cfgInvalid), 0600)
 	require.NoError(t, err)
-	time.Sleep(time.Second * 3) // Might need to rethink this static sleep if test flakiness occurs.  No way currently to hook into when reload finishes
+	time.Sleep(time.Second * 4) // Might need to rethink this static sleep if test flakiness occurs.  No way currently to hook into when reload finishes
 
 	req, err = http.NewRequest(http.MethodGet, "http://localhost:12343/tiles/color2/8/12/32", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Should now only output 1 comment per metric and keep it up to date as additional commits are pushed. Also include if value has increased/decreased