### PR TITLE
Make URL template use proxy behind the scenes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,7 @@ jobs:
           fail_on_error: true
           cache: false
           filter_mode: added
+          golangci_lint_version: v1.64.8
       - name: Suggestions 
         uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2.7.0
         if: success() || failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,7 @@ jobs:
           fail_on_error: false
           cache: false
           filter_mode: file
+          golangci_lint_version: v1.64.8
       - uses: reviewdog/action-suggester@4747dbc9f9e37adba0943e681cc20db466642158 # v1.19.0
         if: success() || failure()
         with:

--- a/internal/providers/proxy.go
+++ b/internal/providers/proxy.go
@@ -60,7 +60,7 @@ func (s ProxyRegistration) Initialize(cfgAny any, clientConfig config.ClientConf
 		cfg.Srid = pkg.SRIDWGS84
 	}
 	if cfg.Srid != pkg.SRIDWGS84 && cfg.Srid != pkg.SRIDPsuedoMercator {
-		return nil, fmt.Errorf(errorMessages.EnumError, "provider.url template.srid", cfg.Srid, []int{pkg.SRIDPsuedoMercator, pkg.SRIDWGS84})
+		return nil, fmt.Errorf(errorMessages.EnumError, "provider.proxy.srid", cfg.Srid, []int{pkg.SRIDPsuedoMercator, pkg.SRIDWGS84})
 	}
 
 	return &Proxy{cfg, clientConfig}, nil

--- a/internal/providers/url_template.go
+++ b/internal/providers/url_template.go
@@ -87,7 +87,7 @@ func (s URLTemplateRegistration) Initialize(cfgAny any, clientConfig config.Clie
 	url = strings.ReplaceAll(url, "$srs", strconv.FormatUint(uint64(cfg.Srid), 10))
 
 	proxyCfg := ProxyConfig{
-		URL: url,
+		URL:  url,
 		Srid: cfg.Srid,
 	}
 

--- a/internal/providers/url_template_test.go
+++ b/internal/providers/url_template_test.go
@@ -17,65 +17,21 @@
 package providers
 
 import (
-	"net/http"
 	"testing"
 
-	"github.com/Michad/tilegroxy/pkg"
 	"github.com/Michad/tilegroxy/pkg/config"
-	"github.com/Michad/tilegroxy/pkg/entities/layer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TODO: change this to something less likely to change
-const testTemplate = "https://tigerweb.geo.census.gov/arcgis/services/TIGERweb/tigerWMS_PhysicalFeatures/MapServer/WMSServer?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetMap&LAYERS=19&STYLES=&CRS=$srs&BBOX=$xmin,$ymin,$xmax,$ymax&WIDTH=$width&HEIGHT=$height&FORMAT=image/png"
 
 func Test_UrlTemplateValidate(t *testing.T) {
 	p, err := URLTemplateRegistration{}.Initialize(URLTemplateConfig{}, config.ClientConfig{}, testErrMessages, nil, nil)
 
 	assert.Nil(t, p)
 	require.Error(t, err)
-}
-func Test_UrlTemplateExecute(t *testing.T) {
-	p, err := URLTemplateRegistration{}.Initialize(URLTemplateConfig{Template: testTemplate}, config.ClientConfig{StatusCodes: []int{http.StatusOK}, MaxLength: 2000, ContentTypes: []string{"image/png"}, UnknownLength: true}, testErrMessages, nil, nil)
 
-	assert.NotNil(t, p)
-	require.NoError(t, err)
-
-	pc, err := p.PreAuth(pkg.BackgroundContext(), layer.ProviderContext{})
-	assert.NotNil(t, pc)
-	require.NoError(t, err)
-
-	img, err := p.GenerateTile(pkg.BackgroundContext(), pc, pkg.TileRequest{LayerName: "layer", Z: 6, X: 10, Y: 10})
-	assert.NotNil(t, img)
-	require.NoError(t, err)
-}
-
-func Test_UrlTemplateConfigOptions(t *testing.T) {
 	var clientConfig = config.ClientConfig{StatusCodes: []int{400}, MaxLength: 2000, ContentTypes: []string{"image/png"}, UnknownLength: true}
-	p, err := URLTemplateRegistration{}.Initialize(URLTemplateConfig{Template: testTemplate}, clientConfig, testErrMessages, nil, nil)
+	p, err = URLTemplateRegistration{}.Initialize(URLTemplateConfig{Template: "url here"}, clientConfig, testErrMessages, nil, nil)
 	assert.NotNil(t, p)
 	require.NoError(t, err)
-
-	img, err := p.GenerateTile(pkg.BackgroundContext(), layer.ProviderContext{}, pkg.TileRequest{LayerName: "layer", Z: 6, X: 10, Y: 10})
-	assert.Nil(t, img)
-	require.Error(t, err)
-
-	clientConfig.StatusCodes = []int{http.StatusOK}
-	clientConfig.MaxLength = 2
-	img, err = p.GenerateTile(pkg.BackgroundContext(), layer.ProviderContext{}, pkg.TileRequest{LayerName: "layer", Z: 6, X: 10, Y: 10})
-	assert.Nil(t, img)
-	require.Error(t, err)
-
-	clientConfig.MaxLength = 2000
-	clientConfig.UnknownLength = false
-	img, err = p.GenerateTile(pkg.BackgroundContext(), layer.ProviderContext{}, pkg.TileRequest{LayerName: "layer", Z: 6, X: 10, Y: 10})
-	assert.Nil(t, img)
-	require.Error(t, err)
-
-	clientConfig.UnknownLength = true
-	clientConfig.ContentTypes = []string{"text/plain"}
-	img, err = p.GenerateTile(pkg.BackgroundContext(), layer.ProviderContext{}, pkg.TileRequest{LayerName: "layer", Z: 6, X: 10, Y: 10})
-	assert.Nil(t, img)
-	require.Error(t, err)
 }


### PR DESCRIPTION
Deletes some redundant code and enables removing tests that rely on census.gov (slight coverage decrease from a single line that returns an error)