### PR TITLE
feat!: Add support for a tenant ID

### DIFF
--- a/docs/operation/modules/ROOT/pages/analytics.adoc
+++ b/docs/operation/modules/ROOT/pages/analytics.adoc
@@ -46,6 +46,9 @@ The following can be included via `fields`:
 | layerparams
 | The placeholder values extracted from a patterned layer name, as a map
 
+| tenantid
+| The tenant identifier established during authentication, if any
+
 | ip
 | The client IP address
 

--- a/docs/operation/modules/ROOT/pages/configuration/authentication/jwt.adoc
+++ b/docs/operation/modules/ROOT/pages/configuration/authentication/jwt.adoc
@@ -68,31 +68,31 @@ Configuration options:
 | 1 day
 
 | ExpectedAudience
-| Require the "aud" grant to be this string
+| Require the "aud" claim to be this string
 | string
 | No
 | None
 
 | ExpectedSubject
-| Require the "sub" grant to be this string
+| Require the "sub" claim to be this string
 | string
 | No
 | None
 
 | ExpectedIssuer
-| Require the "iss" grant to be this string
+| Require the "iss" claim to be this string
 | string
 | No
 | None
 
 | ExpectedScope
-| Require the "scope" grant to contain this string
+| Require the "scope" claim to contain this string
 | string
 | No
 | None
 
 | LayerScope
-| If true the "scope" grant is used to whitelist access to layers
+| If true the "scope" claim is used to whitelist access to layers
 | bool
 | No
 | false
@@ -104,10 +104,16 @@ Configuration options:
 | Empty string
 
 | UserId
-| Use the specified grant as the user identifier. This is just used for logging by default but it's made available to custom providers
+| Use the specified claim as the user identifier. By default this primarily allows identifying who made a request in logs/analytics, however custom providers can use this for more bespoke use cases.
 | string
 | No
 | sub
+
+| TenantId
+| Use the specified claim as the tenant identifier. This is optional and generally only makes sense if you also use User ID. Useful if you have users grouped into some form of account system. It's possible to set this to the same claim as UserID.
+| string
+| No
+| tid
 |===
 
 Example:

--- a/docs/operation/modules/ROOT/pages/extensibility.adoc
+++ b/docs/operation/modules/ROOT/pages/extensibility.adoc
@@ -76,10 +76,10 @@ The following types are available for custom providers:
 
 === Custom Authentication
 
-A custom authentication works much the same way as a custom provider.  The code you need to supply only has access to the standard library.  The package must be "custom" and you must include the following function:
+A custom authentication works much the same way as a custom provider.  The code you need to supply only has access to the standard library plus the `tilegroxy/tilegroxy` package.  The package must be "custom" and you must include the following function:
 
 ----
-func validate(string) (bool, time.Time, string, []string)
+func validate(string) tilegroxy.ValidationResult
 ----
 
 You can optionally also define a `close` function:
@@ -88,14 +88,15 @@ You can optionally also define a `close` function:
 func close(context.Context) error
 ----
 
-The `validate` method will be supplied with a single token.  The function should then return (in order):
+The `validate` method will be supplied with a single token and returns a `ValidationResult` with the following fields:
 
-* pass (bool): Whether the token is valid and should allow the request to proceed
-* expiration (time.Time): When the authentication status of the token expires and the validate method should be called again. `validate` should return pass=false for already expired tokens
-* user identifier (string): An identifier for the user being authenticated. By default this is only used for logging.
-* allowed layers ([]string): The specific layer IDs to allow access to with this specific token. Return an empty array to allow access to all of them.
+* Pass (bool): Whether the token is valid and should allow the request to proceed
+* Expiration (time.Time): When the authentication status of the token expires and the validate method should be called again. `validate` should return Pass=false for already expired tokens
+* UserID (string): An identifier for the user being authenticated. By default this is only used for logging.
+* TenantID (string): An identifier for the tenant/realm/organization/site/group the user belongs to. Omit if not applicable
+* AllowedLayers ([]string): The specific layer IDs to allow access to with this specific token. Leave empty to allow access to all of them.
 
-The method how tokens are extracted from the request is configurable. The following modes are available and if multiple are specified the first one (given the order indicated) in the request is utilized:
+The method by which tokens are extracted is configurable. The following modes are available; if multiple are specified they're tried in the order here:
 
 |===
 | Order | Key | Value
@@ -116,9 +117,6 @@ The method how tokens are extracted from the request is configurable. The follow
 | path
 | None (set as empty string)
 |===
-
-No custom types or methods are available.
-
 
 Close should release any resources your authentication scheme holds.
 

--- a/examples/auth/custom_from_file.go
+++ b/examples/auth/custom_from_file.go
@@ -5,15 +5,17 @@ package custom
 import (
 	"os"
 	"time"
+
+	"tilegroxy/tilegroxy"
 )
 
 // This is intentionally silly
 var password, readErr = os.ReadFile("/tmp/password")
 
-func validate(token string) (bool, time.Time, string, []string) {
+func validate(token string) tilegroxy.ValidationResult {
 	if readErr == nil && string(password) == token {
-		return true, time.Now().Add(1 * time.Hour), "user", []string{"osm"}
+		return tilegroxy.ValidationResult{Pass: true, Expiration: time.Now().Add(1 * time.Hour), UserID: "user", AllowedLayers: []string{"osm"}}
 	}
 
-	return false, time.Now().Add(1000 * time.Hour), "", []string{}
+	return tilegroxy.ValidationResult{Pass: false, Expiration: time.Now().Add(1000 * time.Hour)}
 }

--- a/internal/authentications/custom.go
+++ b/internal/authentications/custom.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -48,34 +49,19 @@ type CustomConfig struct {
 
 type Custom struct {
 	CustomConfig
-	cache *otter.Cache[string, ValidationResult]
+	cache *otter.Cache[string, authentication.ValidationResult]
 	// Only used when cache is used to avoid multiple calls to the validation func for the same token at once
 	locks          keymutex.KeyMutex
-	validationFunc func(string) (bool, time.Time, string, []string)
+	validationFunc func(string) authentication.ValidationResult
 	closeFunc      func(context.Context) error
 }
 
-type ValidationResult struct {
-	pass       bool
-	expiration time.Time
-	uid        string
-	layers     []string
-}
-
-func toResult(pass bool, exp time.Time, uid string, layers []string) ValidationResult {
-	return ValidationResult{pass, exp, uid, layers}
-}
-
-func (v ValidationResult) isGood() bool {
-	if !v.pass {
+func checkValidationResult(v authentication.ValidationResult) bool {
+	if !v.Pass {
 		return false
 	}
 
-	if v.expiration.Before(time.Now()) {
-		return false
-	}
-
-	return true
+	return !v.Expiration.Before(time.Now())
 }
 
 func extractToken(ctx context.Context, req *http.Request, tokenExtract map[string]string) (string, bool) {
@@ -151,6 +137,15 @@ func (s CustomRegistration) Initialize(cfgAny any, deps authentication.Authentic
 		return nil, err
 	}
 
+	err = i.Use(interp.Exports{
+		"tilegroxy/tilegroxy": map[string]reflect.Value{
+			"ValidationResult": reflect.ValueOf((*authentication.ValidationResult)(nil)),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	var script string
 
 	if cfg.File != "" {
@@ -176,7 +171,7 @@ func (s CustomRegistration) Initialize(cfgAny any, deps authentication.Authentic
 		return nil, fmt.Errorf(deps.ErrorMessages.ScriptError, "auth.custom", "nil")
 	}
 
-	validationFunc, ok := validationVal.Interface().(func(string) (bool, time.Time, string, []string))
+	validationFunc, ok := validationVal.Interface().(func(string) authentication.ValidationResult)
 
 	if !ok {
 		return nil, fmt.Errorf(deps.ErrorMessages.ScriptError, "auth.custom", validationVal)
@@ -202,7 +197,7 @@ func (s CustomRegistration) Initialize(cfgAny any, deps authentication.Authentic
 
 	lock := keymutex.NewHashed(-1)
 
-	cache, err := otter.MustBuilder[string, ValidationResult](cfg.CacheSize).Build()
+	cache, err := otter.MustBuilder[string, authentication.ValidationResult](cfg.CacheSize).Build()
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +209,7 @@ func (c Custom) CheckAuthentication(ctx context.Context, req *http.Request) bool
 	slog.Log(ctx, config.LevelTrace, "Performing custom auth check")
 	tok, ok := extractToken(ctx, req, c.Token)
 	if ok {
-		var valResult ValidationResult
+		var valResult authentication.ValidationResult
 		var inCache bool
 
 		if c.cache != nil {
@@ -233,24 +228,27 @@ func (c Custom) CheckAuthentication(ctx context.Context, req *http.Request) bool
 		}
 
 		if !inCache {
-			valResult = toResult(c.validationFunc(tok))
-			slog.DebugContext(ctx, fmt.Sprintf("Custom auth check returned %v", valResult.pass))
+			valResult = c.validationFunc(tok)
+			slog.DebugContext(ctx, fmt.Sprintf("Custom auth check returned %v", valResult.Pass))
 
 			if c.cache != nil {
 				c.cache.Set(tok, valResult)
 			}
 		}
 
-		if valResult.isGood() {
+		if checkValidationResult(valResult) {
 			uid, _ := pkg.UserIDFromContext(ctx)
-			*uid = valResult.uid
+			*uid = valResult.UserID
 
-			if len(valResult.layers) > 0 {
+			tid, _ := pkg.TenantIDFromContext(ctx)
+			*tid = valResult.TenantID
+
+			if len(valResult.AllowedLayers) > 0 {
 				limitLayers, _ := pkg.LimitLayersFromContext(ctx)
 				*limitLayers = true
 
 				allowedLayers, _ := pkg.AllowedLayersFromContext(ctx)
-				*allowedLayers = valResult.layers
+				*allowedLayers = valResult.AllowedLayers
 			}
 			slog.Log(ctx, config.LevelTrace, "Custom auth passed", "result", valResult)
 

--- a/internal/authentications/custom_test.go
+++ b/internal/authentications/custom_test.go
@@ -15,6 +15,7 @@
 package authentications
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,8 +30,8 @@ import (
 // existingRequiredFuncs supplies the minimum validate a custom auth script needs to initialize, so
 // close-specific tests don't have to restate it.
 const existingRequiredFuncs = `
-func validate(token string) (bool, time.Time, string, []string) {
-	return true, time.Now().Add(time.Hour), "user", nil
+func validate(token string) tilegroxy.ValidationResult {
+	return tilegroxy.ValidationResult{Pass: true, Expiration: time.Now().Add(time.Hour), UserID: "user"}
 }
 `
 
@@ -41,6 +42,8 @@ import (
 	"context"
 	"os"
 	"time"
+
+	"tilegroxy/tilegroxy"
 )
 `
 
@@ -92,6 +95,64 @@ func Test_CustomAuthCloseWrongSignatureFailsAtInitialize(t *testing.T) {
 func close() {}
 ` + existingRequiredFuncs
 
+	msgs := config.DefaultConfig().Error.Messages
+
+	a, err := CustomRegistration{}.Initialize(testCustomAuthConfig(script), authentication.AuthenticationDeps{ErrorMessages: msgs})
+
+	assert.Nil(t, a)
+	require.Error(t, err)
+}
+
+func Test_CustomAuthValidate_PopulatesUserAndTenant(t *testing.T) {
+	script := `
+func validate(token string) tilegroxy.ValidationResult {
+	return tilegroxy.ValidationResult{Pass: true, Expiration: time.Now().Add(time.Hour), UserID: "user-1", TenantID: "tenant-1"}
+}
+`
+	a := buildCustomAuthFromScript(t, script)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/tiles/layer/0/0/0", nil)
+	require.NoError(t, err)
+	req.Header["Authorization"] = []string{"sometoken"}
+
+	ctx := pkg.BackgroundContext()
+	require.True(t, a.CheckAuthentication(ctx, req))
+
+	userID, _ := pkg.UserIDFromContext(ctx)
+	tenantID, _ := pkg.TenantIDFromContext(ctx)
+	assert.Equal(t, "user-1", *userID)
+	assert.Equal(t, "tenant-1", *tenantID)
+}
+
+func Test_CustomAuthValidate_TenantOptional(t *testing.T) {
+	// A script that never sets TenantID must leave the context's tenant at its default, not panic
+	// or write a zero-value placeholder that reads as "authenticated but tenantless" incorrectly.
+	script := `
+func validate(token string) tilegroxy.ValidationResult {
+	return tilegroxy.ValidationResult{Pass: true, Expiration: time.Now().Add(time.Hour), UserID: "user-1"}
+}
+`
+	a := buildCustomAuthFromScript(t, script)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/tiles/layer/0/0/0", nil)
+	require.NoError(t, err)
+	req.Header["Authorization"] = []string{"sometoken"}
+
+	ctx := pkg.BackgroundContext()
+	require.True(t, a.CheckAuthentication(ctx, req))
+
+	tenantID, _ := pkg.TenantIDFromContext(ctx)
+	assert.Empty(t, *tenantID)
+}
+
+func Test_CustomAuthValidate_WrongSignatureFailsAtInitialize(t *testing.T) {
+	// The old tuple-return signature is no longer accepted; it must fail at startup with a clear
+	// error rather than silently miscompiling or panicking at request time.
+	script := `
+func validate(token string) (bool, time.Time, string, []string) {
+	return true, time.Now().Add(time.Hour), "user", nil
+}
+`
 	msgs := config.DefaultConfig().Error.Messages
 
 	a, err := CustomRegistration{}.Initialize(testCustomAuthConfig(script), authentication.AuthenticationDeps{ErrorMessages: msgs})

--- a/internal/authentications/jwt.go
+++ b/internal/authentications/jwt.go
@@ -49,6 +49,7 @@ type JWTConfig struct {
 	LayerScope       bool        // If specified, the "scope" grant is used to limit access to layer
 	ScopePrefix      string      // If LayerScope is true, this prefix indicates scopes to use
 	UserID           string      // Use the specified grant as the user identifier. Defaults to sub
+	TenantID         string      // Use the specified grant as the tenant identifier. Defaults to tid
 }
 
 // cachedAuthResult holds everything CheckAuthentication derives from a validated token. A cache
@@ -61,6 +62,7 @@ type cachedAuthResult struct {
 	limitAreaPartial bool
 	allowedArea      pkg.Bounds
 	userID           string
+	tenantID         string
 }
 
 type JWT struct {
@@ -146,6 +148,10 @@ func (s JWTRegistration) Initialize(configAny any, deps authentication.Authentic
 
 	if config.UserID == "" {
 		config.UserID = "sub"
+	}
+
+	if config.TenantID == "" {
+		config.TenantID = "tid"
 	}
 
 	if config.CacheSize == 0 {
@@ -257,6 +263,11 @@ func (r cachedAuthResult) apply(ctx context.Context) {
 			*ctxUserID = r.userID
 		}
 	}
+	if r.tenantID != "" {
+		if ctxTenantID, ok := pkg.TenantIDFromContext(ctx); ok {
+			*ctxTenantID = r.tenantID
+		}
+	}
 }
 
 func (c JWT) extractToken(req *http.Request) (string, bool) {
@@ -339,6 +350,12 @@ func (c JWT) checkAuthenticationWithoutCache(ctx context.Context, tokenStr strin
 			ctxUserID, _ := pkg.UserIDFromContext(ctx)
 			*ctxUserID, _ = rawUID.(string)
 		}
+
+		rawTID := rawClaim[c.TenantID]
+		if rawTID != nil {
+			ctxTenantID, _ := pkg.TenantIDFromContext(ctx)
+			*ctxTenantID, _ = rawTID.(string)
+		}
 	} else {
 		return logInvalidClaimsType(ctx, tokenJwt)
 	}
@@ -358,6 +375,9 @@ func (c JWT) checkAuthenticationWithoutCache(ctx context.Context, tokenStr strin
 	}
 	if ctxUserID, ok := pkg.UserIDFromContext(ctx); ok {
 		result.userID = *ctxUserID
+	}
+	if ctxTenantID, ok := pkg.TenantIDFromContext(ctx); ok {
+		result.tenantID = *ctxTenantID
 	}
 
 	return &result, true

--- a/internal/authentications/jwt_test.go
+++ b/internal/authentications/jwt_test.go
@@ -206,6 +206,7 @@ func TestGoodJwtScopeLimit_CacheHitPreservesAuthorization(t *testing.T) {
 		LayerScope:    true,
 		ScopePrefix:   "tile/",
 		UserID:        "name",
+		TenantID:      "tid",
 		CacheSize:     100,
 	}
 	jwtAny, err := JWTRegistration{}.Initialize(jwtConfig, authentication.AuthenticationDeps{ErrorMessages: config.ErrorMessages{}})
@@ -214,7 +215,7 @@ func TestGoodJwtScopeLimit_CacheHitPreservesAuthorization(t *testing.T) {
 
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/tiles/layer/0/0/0", nil)
 	require.NoError(t, err)
-	req.Header["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWJqZWN0IiwiYXVkIjoiYXVkaWVuY2UiLCJpc3MiOiJpc3N1ZXIiLCJzY29wZSI6InRpbGUvdGVzdCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo0Mjk0OTY3Mjk1fQ.j_-4ERnaVdkscbfjMKavieAtVH7GhZIBr5kwnKNHEAI"} // Valid JWT with scope=tile/test
+	req.Header["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdWRpZW5jZSIsImV4cCI6NDI5NDk2NzI5NSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJpc3N1ZXIiLCJuYW1lIjoiSm9obiBEb2UiLCJzY29wZSI6InRpbGUvdGVzdCIsInN1YiI6InN1YmplY3QiLCJ0aWQiOiJhY21lLWNvcnAifQ.p2yraK0p8aMnikjWJJ1Ljv_dwxD7YvdOW5KLC-sxCUQ"} // Valid JWT with scope=tile/test and tid=acme-corp
 
 	// Request 1: cache miss, does the full validation.
 	ctx1 := pkg.BackgroundContext()
@@ -226,6 +227,8 @@ func TestGoodJwtScopeLimit_CacheHitPreservesAuthorization(t *testing.T) {
 	require.True(t, *limitLayers1)
 	require.Equal(t, []string{"test"}, *allowedLayers1)
 	require.Equal(t, "John Doe", *userID1)
+	tenantID1, _ := pkg.TenantIDFromContext(ctx1)
+	require.Equal(t, "acme-corp", *tenantID1)
 
 	// Request 2: same token, now served from cache. Must produce the identical restrictions.
 	ctx2 := pkg.BackgroundContext()
@@ -238,6 +241,56 @@ func TestGoodJwtScopeLimit_CacheHitPreservesAuthorization(t *testing.T) {
 	assert.True(t, *limitLayers2, "cache hit must not drop limitLayers back to false")
 	assert.Equal(t, []string{"test"}, *allowedLayers2, "cache hit must not drop the allowed layers")
 	assert.Equal(t, "John Doe", *userID2, "cache hit must not drop the user ID")
+	tenantID2, _ := pkg.TenantIDFromContext(ctx2)
+	assert.Equal(t, "acme-corp", *tenantID2, "cache hit must not drop the tenant ID")
+}
+
+func TestGoodJwtTenantId(t *testing.T) {
+	jwtConfig := JWTConfig{
+		Algorithm:     "HS256",
+		Key:           "hunter2",
+		MaxExpiration: 4294967295, // 136 years from now
+		UserID:        "name",
+		TenantID:      "tid",
+	}
+	jwt, err := JWTRegistration{}.Initialize(jwtConfig, authentication.AuthenticationDeps{ErrorMessages: config.ErrorMessages{}})
+
+	require.NoError(t, err)
+	require.NotNil(t, jwt)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/tiles/layer/0/0/0", nil)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	ctx := pkg.BackgroundContext()
+
+	req.Header["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdWRpZW5jZSIsImV4cCI6NDI5NDk2NzI5NSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJpc3N1ZXIiLCJuYW1lIjoiSm9obiBEb2UiLCJzY29wZSI6InRpbGUvdGVzdCIsInN1YiI6InN1YmplY3QiLCJ0aWQiOiJhY21lLWNvcnAifQ.p2yraK0p8aMnikjWJJ1Ljv_dwxD7YvdOW5KLC-sxCUQ"}
+	assert.True(t, jwt.CheckAuthentication(ctx, req))
+
+	ctxUserID, _ := pkg.UserIDFromContext(ctx)
+	ctxTenantID, _ := pkg.TenantIDFromContext(ctx)
+	assert.Equal(t, "John Doe", *ctxUserID)
+	assert.Equal(t, "acme-corp", *ctxTenantID)
+}
+
+func TestGoodJwtTenantId_DefaultClaimName(t *testing.T) {
+	jwtConfig := JWTConfig{
+		Algorithm:     "HS256",
+		Key:           "hunter2",
+		MaxExpiration: 4294967295, // 136 years from now
+	}
+	jwt, err := JWTRegistration{}.Initialize(jwtConfig, authentication.AuthenticationDeps{ErrorMessages: config.ErrorMessages{}})
+	require.NoError(t, err)
+
+	ctx := pkg.BackgroundContext()
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/tiles/layer/0/0/0", nil)
+	require.NoError(t, err)
+	req.Header["Authorization"] = []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhdWRpZW5jZSIsImV4cCI6NDI5NDk2NzI5NSwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJpc3N1ZXIiLCJuYW1lIjoiSm9obiBEb2UiLCJzY29wZSI6InRpbGUvdGVzdCIsInN1YiI6InN1YmplY3QiLCJ0aWQiOiJhY21lLWNvcnAifQ.p2yraK0p8aMnikjWJJ1Ljv_dwxD7YvdOW5KLC-sxCUQ"}
+
+	assert.True(t, jwt.CheckAuthentication(ctx, req))
+
+	ctxTenantID, _ := pkg.TenantIDFromContext(ctx)
+	assert.Equal(t, "acme-corp", *ctxTenantID, "TenantID should default to reading the 'tid' claim")
 }
 
 func TestBadJwtClaims(t *testing.T) {

--- a/internal/server/tile_handler_test.go
+++ b/internal/server/tile_handler_test.go
@@ -220,12 +220,14 @@ func Test_TileHandler_ExecuteCustom(t *testing.T) {
     import (
     	"os"
     	"time"
+
+    	"tilegroxy/tilegroxy"
     )
-    func validate(token string) (bool, time.Time, string, []string) {
+    func validate(token string) tilegroxy.ValidationResult {
     	if string(token) == "hunter2" {
-    		return true, time.Now().Add(1 * time.Hour), "user", []string{"color"}
+    		return tilegroxy.ValidationResult{Pass: true, Expiration: time.Now().Add(1 * time.Hour), UserID: "user", AllowedLayers: []string{"color"}}
     	}
-    	return false, time.Now().Add(1000 * time.Hour), "", []string{}
+    	return tilegroxy.ValidationResult{Pass: false, Expiration: time.Now().Add(1000 * time.Hour)}
     }`
 
 	cache := caches.Noop{}

--- a/pkg/entities/analytics/event_fields.go
+++ b/pkg/entities/analytics/event_fields.go
@@ -31,6 +31,7 @@ import (
 const (
 	FieldLayerName   = "layername"
 	FieldLayerParams = "layerparams"
+	FieldTenantID    = "tenantid"
 	FieldIP          = "ip"
 	FieldUserAgent   = "useragent"
 	FieldReferer     = "referer"
@@ -48,6 +49,7 @@ const (
 var AllFields = []string{
 	FieldLayerName,
 	FieldLayerParams,
+	FieldTenantID,
 	FieldIP,
 	FieldUserAgent,
 	FieldReferer,
@@ -164,6 +166,12 @@ func resolveNamedField(ctx context.Context, name string, src FieldSource) (any, 
 			return nil, false
 		}
 		return *matches, true
+	case FieldTenantID:
+		tenant, ok := pkg.TenantIDFromContext(ctx)
+		if !ok || tenant == nil {
+			return nil, false
+		}
+		return *tenant, true
 	case FieldDuration:
 		start, ok := pkg.StartTimeFromContext(ctx)
 		if !ok {

--- a/pkg/entities/analytics/event_fields_test.go
+++ b/pkg/entities/analytics/event_fields_test.go
@@ -35,7 +35,12 @@ func testRequestContext(t *testing.T) context.Context {
 	req.Header.Set("Referer", "http://example.com/map")
 	req.Header.Set("X-Tenant-Id", "acme")
 
-	return pkg.NewRequestContext(req)
+	ctx := pkg.NewRequestContext(req)
+
+	tenant, _ := pkg.TenantIDFromContext(ctx)
+	*tenant = "tenant-from-auth"
+
+	return ctx
 }
 
 func Test_FieldResolver_RejectsUnknownField(t *testing.T) {
@@ -64,10 +69,27 @@ func Test_FieldResolver_AcceptsAllKnownFields(t *testing.T) {
 	assert.Equal(t, "main", out[FieldLayerName])
 	assert.Equal(t, 42, out[FieldBytes])
 	assert.Equal(t, "image/png", out[FieldContentType])
+	assert.Equal(t, "tenant-from-auth", out[FieldTenantID])
 	assert.Equal(t, "10.1.2.3", out[FieldIP])
 	assert.Equal(t, "test-agent", out[FieldUserAgent])
 	assert.Equal(t, "http://example.com/map", out[FieldReferer])
 	assert.Equal(t, http.MethodGet, out[FieldMethod])
+}
+
+func Test_FieldResolver_TenantIDDefaultsToEmptyString(t *testing.T) {
+	msgs := config.DefaultConfig().Error.Messages
+
+	r, err := newFieldResolver(map[string]interface{}{"fields": []string{"tenantid"}}, msgs)
+	require.NoError(t, err)
+
+	// A request that never went through tenant-aware auth still has a context-provided empty
+	// string, not an absent field - matches how UserID/TenantID behave elsewhere.
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/tiles/main/1/2/3", nil)
+	ctx := pkg.NewRequestContext(req)
+
+	out := r.Resolve(ctx, FieldSource{})
+
+	assert.Empty(t, out[FieldTenantID])
 }
 
 func Test_FieldResolver_CaseInsensitiveFieldNames(t *testing.T) {

--- a/pkg/entities/authentication/validation_result.go
+++ b/pkg/entities/authentication/validation_result.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Michael Davis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authentication
+
+import "time"
+
+// ValidationResult is returned by a custom authentication script's validate function. Fields are
+// added here rather than as new return values so adding a capability never requires another
+// breaking change to the validate signature.
+type ValidationResult struct {
+	// Whether the token is valid and should allow the request to proceed
+	Pass bool
+	// When the authentication status of the token expires and validate should be called again.
+	// Pass should be false for already-expired tokens
+	Expiration time.Time
+	// An identifier for the user being authenticated. By default this is only used for logging
+	UserID string
+	// An identifier for the tenant/organization the user belongs to. By default this is only
+	// used for logging and analytics
+	TenantID string
+	// The specific layer IDs to allow access to with this token. Leave empty to allow all layers
+	AllowedLayers []string
+}

--- a/pkg/entities/authentication/validation_result_test.go
+++ b/pkg/entities/authentication/validation_result_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Michael Davis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authentication_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Michad/tilegroxy/pkg/entities/authentication"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidationResult_FieldsAreIndependentlyAddressable(t *testing.T) {
+	exp := time.Now().Add(time.Hour)
+	r := authentication.ValidationResult{
+		Pass:          true,
+		Expiration:    exp,
+		UserID:        "user-1",
+		TenantID:      "tenant-1",
+		AllowedLayers: []string{"osm"},
+	}
+
+	assert.True(t, r.Pass)
+	assert.Equal(t, exp, r.Expiration)
+	assert.Equal(t, "user-1", r.UserID)
+	assert.Equal(t, "tenant-1", r.TenantID)
+	assert.Equal(t, []string{"osm"}, r.AllowedLayers)
+}
+
+func Test_ValidationResult_ZeroValueIsUnauthenticated(t *testing.T) {
+	var r authentication.ValidationResult
+
+	assert.False(t, r.Pass)
+	assert.Empty(t, r.UserID)
+	assert.Empty(t, r.TenantID)
+	assert.Empty(t, r.AllowedLayers)
+}

--- a/pkg/entry/seed.go
+++ b/pkg/entry/seed.go
@@ -46,7 +46,7 @@ type SeedOptions struct {
 	NumThread    uint16
 	ProgressFile string
 	CacheName    string
-	MaxFailures uint64
+	MaxFailures  uint64
 }
 
 func Seed(cfg *config.Config, opts SeedOptions, out io.Writer) error {

--- a/pkg/request_context.go
+++ b/pkg/request_context.go
@@ -34,6 +34,7 @@ const allowedLayersKey = "allowedLayers"
 const limitAreaPartialKey = "limitAreaPartial"
 const allowedAreaKey = "allowedArea"
 const userIDKey = "user"
+const tenantIDKey = "tenant"
 const layerPatternMatchesKey = "layerPatternMatches"
 const refDepthKey = "refDepth"
 
@@ -52,6 +53,7 @@ func NewRequestContext(req *http.Request) context.Context {
 	ctx = context.WithValue(ctx, limitAreaPartialKey, p(false))
 	ctx = context.WithValue(ctx, allowedAreaKey, &Bounds{})
 	ctx = context.WithValue(ctx, userIDKey, p(""))
+	ctx = context.WithValue(ctx, tenantIDKey, p(""))
 	ctx = context.WithValue(ctx, layerPatternMatchesKey, &map[string]string{})
 	ctx = context.WithValue(ctx, refDepthKey, p(0))
 
@@ -117,6 +119,12 @@ func UserIDFromContext(ctx context.Context) (*string, bool) {
 	return u, ok
 }
 
+// If auth specifies a way to retrieve a tenant identifier, it's contained here
+func TenantIDFromContext(ctx context.Context) (*string, bool) {
+	u, ok := ctx.Value(tenantIDKey).(*string)
+	return u, ok
+}
+
 // Maps any parameters in the layer name from their key defined in config to the value from the real URL
 func LayerPatternMatchesFromContext(ctx context.Context) (*map[string]string, bool) {
 	u, ok := ctx.Value(layerPatternMatchesKey).(*map[string]string)
@@ -140,6 +148,7 @@ func CopyAuthRestrictions(from, to context.Context) {
 	copyPtr(from, to, LimitAreaPartialFromContext)
 	copyPtr(from, to, AllowedAreaFromContext)
 	copyPtr(from, to, UserIDFromContext)
+	copyPtr(from, to, TenantIDFromContext)
 }
 
 func copyPtr[A any](from, to context.Context, get func(context.Context) (*A, bool)) {

--- a/pkg/request_context_test.go
+++ b/pkg/request_context_test.go
@@ -41,6 +41,9 @@ func Test_CopyAuthRestrictions(t *testing.T) {
 	user, ok := pkg.UserIDFromContext(from)
 	require.True(t, ok)
 	*user = "someone"
+	tenant, ok := pkg.TenantIDFromContext(from)
+	require.True(t, ok)
+	*tenant = "acme-corp"
 
 	pkg.CopyAuthRestrictions(from, to)
 
@@ -54,6 +57,8 @@ func Test_CopyAuthRestrictions(t *testing.T) {
 	assert.Equal(t, pkg.Bounds{South: 1, North: 2, West: 3, East: 4}, *newArea)
 	newUser, _ := pkg.UserIDFromContext(to)
 	assert.Equal(t, "someone", *newUser)
+	newTenant, _ := pkg.TenantIDFromContext(to)
+	assert.Equal(t, "acme-corp", *newTenant)
 }
 
 // Copying must not alias, so a later change to one context can't reach the other.
@@ -77,4 +82,14 @@ func Test_CopyAuthRestrictions_MissingValues(t *testing.T) {
 
 	assert.NotPanics(t, func() { pkg.CopyAuthRestrictions(t.Context(), to) })
 	assert.NotPanics(t, func() { pkg.CopyAuthRestrictions(to, t.Context()) })
+}
+
+// A freshly built request context has an empty, non-nil tenant ID, mirroring UserIDFromContext's
+// default so field resolvers can treat "unset" and "empty string" the same way.
+func Test_TenantIDFromContext_DefaultsToEmptyString(t *testing.T) {
+	ctx := pkg.BackgroundContext()
+
+	tenant, ok := pkg.TenantIDFromContext(ctx)
+	require.True(t, ok)
+	assert.Empty(t, *tenant)
 }


### PR DESCRIPTION
Breaking change: custom authentication now returns a struct instead of a long list of parameters