### PR TITLE
feat!: add seed --purge

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -28,13 +28,16 @@ var seedCmd = &cobra.Command{
 	Short: "Pre-populate (seed) the cache",
 	Long: `Pre-populates the cache for a given layer for a given area (bounding box) for a range of zoom levels. 
 	
-Be mindful that the greater the zoom level (the more you "zoom in"), exponentially more tiles will need to be seeded for a given area. For instance, while zoom level 1 only requires 4 tiles to cover the planet, zoom level 10 requires over a million tiles.
+Be mindful that the greater the zoom level (the more you "zoom in"), exponentially more tiles will need to be seeded for a given area. For instance, while zoom level 1 only requires 4 tiles to cover the planet, zoom level 10 requires over a million tiles. As a safety precaution, a limit of 10k tiles is applied unless you specify --force.
+
+Pass --purge to delete the tiles covering the same area instead of populating them. Purging makes no requests against upstream providers, so it isn't subject to the --force tile limit.
 
 Seed jobs can be resumed automatically by specifying a file with the --progress flag. Job progress will be written to that file as we go. Interrupting the command and then running the exact same command again, will start off more-or-less from where things left off. The file will be overwritten with progress and should get deleted once done. 
 
 Example:
 
-	tilegroxy seed -c test_config.yml -l osm -z 2 -v -t 7 -z 0 -z 1 -z 3 -z 4 --progress seed_job.json`,
+	tilegroxy seed -c test_config.yml -l osm -z 2 -v -t 7 -z 0 -z 1 -z 3 -z 4 --progress seed_job.json
+	tilegroxy seed -c test_config.yml -l osm -z 5 --purge`,
 	Run: runSeed,
 }
 
@@ -51,9 +54,10 @@ func runSeed(cmd *cobra.Command, _ []string) {
 	progressFile, err10 := cmd.Flags().GetString("progress")
 	cacheName, err11 := cmd.Flags().GetString("cache")
 	maxFailures, err12 := cmd.Flags().GetUint64("max-failures")
+	purge, err13 := cmd.Flags().GetBool("purge")
 	out := rootCmd.OutOrStdout()
 
-	if err := errors.Join(err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12); err != nil {
+	if err := errors.Join(err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13); err != nil {
 		fmt.Fprintf(out, "Error: %v", err)
 		exit(1)
 		return
@@ -78,7 +82,8 @@ func runSeed(cmd *cobra.Command, _ []string) {
 			NumThread:    numThread,
 			ProgressFile: progressFile,
 			CacheName:    cacheName,
-			MaxFailures:  maxFailures},
+			MaxFailures:  maxFailures,
+			Purge:        purge},
 		out)
 
 	if err != nil {
@@ -106,7 +111,9 @@ func initSeed() {
 	seedCmd.Flags().Uint16P("threads", "t", 1, "How many concurrent requests to use to perform seeding. Be mindful of spamming upstream providers")
 	seedCmd.Flags().StringP("progress", "p", "", "A file to use to record how far the seed got. If the file already exists the seed resumes from its recorded position instead of starting over.")
 	seedCmd.Flags().Uint64("max-failures", 0, "How many tiles can fail to render before the seed gives up and exits with a failure status. \nDefaults to the number of tiles being seeded, meaning the seed only fails if every tile does")
+	seedCmd.Flags().Bool("purge", false, "Delete the cached tiles covering the given area and zoom levels instead of populating them.")
 	seedCmd.Flags().String("cache", "", "For a layer using a multi-tiered cache, restrict seeding to the tier of this type (e.g. \"disk\"). By default every tier is seeded.")
+	seedCmd.MarkFlagsMutuallyExclusive("force", "purge")
 
 	if err != nil {
 		panic(err)

--- a/cmd/seed_test.go
+++ b/cmd/seed_test.go
@@ -266,3 +266,50 @@ func Test_SeedCommand_MismatchedProgressFile(t *testing.T) {
 	assert.Contains(t, string(out), "different seed run")
 	assert.Equal(t, 1, exitStatus)
 }
+
+func Test_SeedCommand_Purge(t *testing.T) {
+	exitStatus = -1
+	rootCmd.ResetFlags()
+	seedCmd.ResetFlags()
+	initRoot()
+	initSeed()
+
+	b := bytes.NewBufferString("")
+	rootCmd.SetOut(b)
+	rootCmd.SetErr(b)
+	rootCmd.SetArgs([]string{"seed", "--verbose", "-c", "../examples/configurations/simple.json", "-l", "osm", "-z", "0", "--purge"})
+	require.NoError(t, rootCmd.Execute())
+	out, err := io.ReadAll(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(out))
+
+	// The cache is "none", so nothing is there to remove, but the count still gets reported.
+	assert.Contains(t, string(out), "Removed 0 of 1 tiles")
+	assert.Contains(t, string(out), "Completed purging")
+	assert.Equal(t, -1, exitStatus)
+}
+
+// A purge makes no upstream requests, so the --force tile limit doesn't apply to it.
+func Test_SeedCommand_PurgeIgnoresTileLimit(t *testing.T) {
+	exitStatus = -1
+	rootCmd.ResetFlags()
+	seedCmd.ResetFlags()
+	initRoot()
+	initSeed()
+
+	b := bytes.NewBufferString("")
+	rootCmd.SetOut(b)
+	rootCmd.SetErr(b)
+	rootCmd.SetArgs([]string{"seed", "-c", "../examples/configurations/simple.json", "-l", "osm", "-z", "8", "-n", "1", "-s", "0", "-w", "0", "-e", "1", "--purge"})
+	require.NoError(t, rootCmd.Execute())
+	out, err := io.ReadAll(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotContains(t, string(out), "--force")
+	assert.Equal(t, -1, exitStatus)
+}

--- a/docs/operation/modules/ROOT/pages/commands/seed.adoc
+++ b/docs/operation/modules/ROOT/pages/commands/seed.adoc
@@ -2,6 +2,8 @@
 
 A helper command to allow you to prepopulate your cache with prerendered tiles. This is especially useful when adding a new layer to tilegroxy that is slow to render the furthest out zoom levels and you want to avoid your first end-users running into this slowness. This command is roughly equivalent to standing up a server using the `serve` command and then hitting the layer endpoint with `cURL` requests for all the tiles you want.
 
+The same command can also remove cached tiles with the `--purge` flag. A purge walks the same layer, bounding box and zoom levels a seed would but deletes the matching cache entries instead of populating them.
+
 Full, up-to-date usage information can be found with `tilegroxy seed -h`.
 
 ----
@@ -11,13 +13,19 @@ for a range of zoom levels.
 Be mindful that the greater the zoom level (the more you "zoom in"),
 exponentially more tiles will need to be seeded for a given area. For
 instance, while zoom level 1 only requires 4 tiles to cover the planet,
-zoom level 10 requires over a million tiles.
+zoom level 10 requires over a million tiles. As a safety precaution, a
+limit of 10k tiles is applied unless you specify --force.
+
+Pass --purge to delete the tiles covering the same area instead of
+populating them. Purging makes no requests against upstream providers,
+so it isn't subject to the --force tile limit.
 
 Seed jobs can be resumed automatically by specifying a file with the --progress flag. Job progress will be written to that file as we go. Interrupting the command and then running the exact same command again, will start off more-or-less from where things left off. The file will be overwritten with progress and should get deleted once done. 
 
 Example:
 
 	tilegroxy seed -c test_config.yml -l osm -z 2 -v -t 7 -z 0 -z 1 -z 3 -z 4 --progress seed_job.json
+	tilegroxy seed -c test_config.yml -l osm -z 5 --purge
 
 Usage:
   tilegroxy seed [flags]
@@ -49,6 +57,9 @@ Flags:
                                 side of the bounding box (default -180)
   -p, --progress string         A file to use to record how far the seed 
                                 got. If the file already exists the seed resumes from its recorded position instead of starting over.
+      --purge                   Delete the cached tiles covering the
+                                given area and zoom levels instead of
+                                populating them.
   -t, --threads uint16          How many concurrent requests to use to
                                 perform seeding. Be mindful of spamming
                                 upstream providers (default 1)

--- a/docs/operation/modules/ROOT/pages/configuration/cache/index.adoc
+++ b/docs/operation/modules/ROOT/pages/configuration/cache/index.adoc
@@ -2,6 +2,6 @@
 
 The cache configuration defines the datastores where tiles should be stored/retrieved. We recommended you use a `multi`-tiered cache with a smaller, faster "near" cache first followed by a larger, slower "far" cache.
 
-There is no universal mechanism for expiring or deleting cache entries. Some cache options include built-in mechanisms for applying an TTL and maximum size, however some require an external cleanup mechanism if desired. Be mindful of this as some options may incur their own costs if allowed to grow unchecked. 
+There is no universal mechanism for expiring cache entries. Some cache options include built-in mechanisms for applying an TTL and maximum size, however some require an external cleanup mechanism if desired. Be mindful of this as some options may incur their own costs if allowed to grow unchecked. To delete entries covering a specific area, use xref:commands/seed.adoc[the seed command] with `--purge`.
 
 When specifying a cache ensure you include the `name` parameter.

--- a/internal/caches/disk.go
+++ b/internal/caches/disk.go
@@ -102,3 +102,18 @@ func (c Disk) Save(_ context.Context, t pkg.TileRequest, img *pkg.Image) error {
 
 	return os.WriteFile(filepath.Clean(filepath.Join(c.Path, filename)), b, fs.FileMode(c.FileMode))
 }
+
+func (c Disk) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	filename := requestToFilename(t)
+
+	err := os.Remove(filepath.Clean(filepath.Join(c.Path, filename)))
+
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/caches/disk_test.go
+++ b/internal/caches/disk_test.go
@@ -36,6 +36,7 @@ func TestDisk(t *testing.T) {
 	c, err := DiskRegistration{}.Initialize(cfg, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
 	require.NoError(t, err)
 	validateSaveAndLookup(t, c)
+	validateRemove(t, c)
 }
 
 // LayerName is User input for pattern layers, so a traversal sequence in it must not let

--- a/internal/caches/memcached.go
+++ b/internal/caches/memcached.go
@@ -163,3 +163,16 @@ func (c Memcached) Save(_ context.Context, t pkg.TileRequest, img *pkg.Image) er
 
 	return c.client.Set(&memcache.Item{Key: memcachedKey(c.KeyPrefix, t), Value: val, Expiration: int32(c.TTL)}) // #nosec G115 -- max value applied in Initialize
 }
+
+func (c Memcached) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	err := c.client.Delete(memcachedKey(c.KeyPrefix, t))
+
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/caches/memcached_test.go
+++ b/internal/caches/memcached_test.go
@@ -87,6 +87,7 @@ func TestMemcachedWithContainerHostAndPort(t *testing.T) {
 	r, err := MemcachedRegistration{}.Initialize(cfg, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
 	require.NoError(t, err)
 	validateSaveAndLookup(t, r)
+	validateRemove(t, r)
 }
 
 func TestMemcachedWithContainerSingleServersArr(t *testing.T) {

--- a/internal/caches/memory.go
+++ b/internal/caches/memory.go
@@ -91,3 +91,13 @@ func (c Memory) Save(_ context.Context, t pkg.TileRequest, img *pkg.Image) error
 	c.Cache.Set(t.String(), *img)
 	return nil
 }
+
+func (c Memory) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	key := t.String()
+
+	// otter's Delete reports nothing, so presence has to be checked separately.
+	present := c.Cache.Has(key)
+	c.Cache.Delete(key)
+
+	return present, nil
+}

--- a/internal/caches/memory_test.go
+++ b/internal/caches/memory_test.go
@@ -31,6 +31,7 @@ func TestMemory(t *testing.T) {
 	require.NoError(t, err)
 
 	validateSaveAndLookup(t, r)
+	validateRemove(t, r)
 }
 
 func TestTtl(t *testing.T) {

--- a/internal/caches/multi.go
+++ b/internal/caches/multi.go
@@ -103,3 +103,18 @@ func (c Multi) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) erro
 
 	return allErrors
 }
+
+// Every tier is covered because a hit in any one of them would otherwise resurrect the tile.
+func (c Multi) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	var allErrors error
+
+	anyRemoved := false
+
+	for _, cache := range c.Tiers {
+		removed, err := cache.Remove(ctx, t)
+		anyRemoved = anyRemoved || removed
+		allErrors = errors.Join(allErrors, err)
+	}
+
+	return anyRemoved, allErrors
+}

--- a/internal/caches/multi_test.go
+++ b/internal/caches/multi_test.go
@@ -84,3 +84,47 @@ func TestMultiIn2(t *testing.T) {
 
 	validateLookup(t, multi, tile, &img)
 }
+
+func TestMultiRemove(t *testing.T) {
+	mem1, err := MemoryRegistration{}.Initialize(MemoryConfig{}, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
+	require.NoError(t, err)
+
+	mem2, err := MemoryRegistration{}.Initialize(MemoryConfig{}, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
+	require.NoError(t, err)
+
+	multi := Multi{Tiers: []cache.Cache{mem1, mem2}}
+
+	tile := makeReq(53)
+	img := makeImg(24)
+	require.NoError(t, multi.Save(context.Background(), tile, &img))
+
+	removed, err := multi.Remove(context.Background(), tile)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	validateNoLookup(t, multi, tile)
+	validateNoLookup(t, mem1, tile)
+	validateNoLookup(t, mem2, tile)
+}
+
+// A tile left behind in any single tier would be served again on the next lookup.
+func TestMultiRemoveClearsTierWithOnlyCopy(t *testing.T) {
+	mem1, err := MemoryRegistration{}.Initialize(MemoryConfig{}, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
+	require.NoError(t, err)
+
+	mem2, err := MemoryRegistration{}.Initialize(MemoryConfig{}, cache.CacheDeps{ErrorMessages: config.ErrorMessages{}})
+	require.NoError(t, err)
+
+	multi := Multi{Tiers: []cache.Cache{mem1, mem2}}
+
+	tile := makeReq(71)
+	img := makeImg(24)
+	require.NoError(t, mem2.Save(context.Background(), tile, &img))
+
+	// Only one tier held the tile, but the tile itself was still removed.
+	removed, err := multi.Remove(context.Background(), tile)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	validateNoLookup(t, multi, tile)
+}

--- a/internal/caches/noop.go
+++ b/internal/caches/noop.go
@@ -55,3 +55,7 @@ func (c Noop) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) {
 func (c Noop) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
 	return nil
 }
+
+func (c Noop) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, nil
+}

--- a/internal/caches/redis.go
+++ b/internal/caches/redis.go
@@ -55,6 +55,9 @@ type Redis struct {
 	// expose what it wraps, so we have to hold onto it ourselves. Left nil when the client comes
 	// from a shared datastore, since the datastore registry owns closing it in that case.
 	client io.Closer
+	// The same client, held separately because Remove needs DEL's reply count, which
+	// rediscache.Cache discards. Always set, unlike client.
+	redis redis.UniversalClient
 }
 
 func init() {
@@ -110,7 +113,7 @@ func initializeRedisFromDatastore(config RedisConfig, deps cache.CacheDeps) (cac
 		return nil, fmt.Errorf(deps.ErrorMessages.InvalidParam, "cache.redis.datastore", config.Datastore)
 	}
 
-	return &Redis{RedisConfig: config, cache: newRedisTileCache(client), client: nil}, nil
+	return &Redis{RedisConfig: config, cache: newRedisTileCache(client), client: nil, redis: client}, nil
 }
 
 // initializeRedisDirect builds a redis connection from the cache's own inline connection fields
@@ -139,7 +142,7 @@ func initializeRedisDirect(config RedisConfig, deps cache.CacheDeps) (cache.Cach
 
 	client := ds.Native().(redis.UniversalClient)
 
-	return &Redis{RedisConfig: config, cache: newRedisTileCache(client), client: client}, nil
+	return &Redis{RedisConfig: config, cache: newRedisTileCache(client), client: client, redis: client}, nil
 }
 
 func newRedisTileCache(client redis.UniversalClient) *rediscache.Cache {
@@ -190,4 +193,21 @@ func (c Redis) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) erro
 	})
 
 	return err
+}
+
+// DEL replies with how many keys it actually removed, which rediscache.Cache discards, so this
+// goes to the client directly.
+func (c Redis) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	key := c.KeyPrefix + t.String()
+
+	deleted, err := c.redis.Del(ctx, key).Result()
+
+	if errors.Is(err, rediscache.ErrCacheMiss) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return deleted > 0, nil
 }

--- a/internal/caches/redis_test.go
+++ b/internal/caches/redis_test.go
@@ -88,6 +88,7 @@ func TestRedisWithContainerHostAndPort(t *testing.T) {
 	require.NoError(t, err)
 
 	validateSaveAndLookup(t, r)
+	validateRemove(t, r)
 }
 
 func TestRedisWithContainerSingleServersArr(t *testing.T) {

--- a/internal/caches/s3.go
+++ b/internal/caches/s3.go
@@ -187,3 +187,35 @@ func (c S3) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) error {
 	_, err = c.transfer.UploadObject(ctx, uploadConfig)
 	return err
 }
+
+func (c S3) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	key := calcKey(&c, &t)
+
+	// DeleteObject succeeds identically whether or not the key was there, so reporting what was
+	// actually removed costs a HEAD first.
+	_, err := c.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(c.Bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		var notFound *types.NotFound
+		var noSuchKey *types.NoSuchKey
+		if errors.As(err, &notFound) || errors.As(err, &noSuchKey) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	_, err = c.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(c.Bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/caches/s3_test.go
+++ b/internal/caches/s3_test.go
@@ -115,6 +115,7 @@ func Test_S3Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	validateSaveAndLookup(t, s3)
+	validateRemove(t, s3)
 	img, err := s3.Lookup(context.Background(), pkg.TileRequest{LayerName: "layer", Z: 93, X: 53, Y: 12345})
 	assert.Nil(t, img)
 	require.NoError(t, err)

--- a/internal/caches/tenant.go
+++ b/internal/caches/tenant.go
@@ -88,6 +88,10 @@ func (c *TenantCache) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Imag
 	return c.Cache.Save(ctx, namespace(ctx, t), img)
 }
 
+func (c *TenantCache) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	return c.Cache.Remove(ctx, namespace(ctx, t))
+}
+
 func (c *TenantCache) Close(ctx context.Context) error {
 	return lifecycle.CloseIfCloser(ctx, c.Cache)
 }

--- a/internal/caches/tenant_test.go
+++ b/internal/caches/tenant_test.go
@@ -175,3 +175,28 @@ func Test_TenantRegistration_RegisteredUnderName(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "tenant", reg.Name())
 }
+
+func Test_TenantCache_RemoveOnlyAffectsOwnTenant(t *testing.T) {
+	inner := newMemCache()
+	c := NewTenantCache(inner)
+	req := testTileRequest()
+
+	ctxA := contextWithTenant(t, "tenant-a")
+	ctxB := contextWithTenant(t, "tenant-b")
+
+	require.NoError(t, c.Save(ctxA, req, &pkg.Image{Content: []byte("a-data")}))
+	require.NoError(t, c.Save(ctxB, req, &pkg.Image{Content: []byte("b-data")}))
+
+	removed, err := c.Remove(ctxA, req)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	imgA, err := c.Lookup(ctxA, req)
+	require.NoError(t, err)
+	require.Nil(t, imgA)
+
+	imgB, err := c.Lookup(ctxB, req)
+	require.NoError(t, err)
+	require.NotNil(t, imgB)
+	require.Equal(t, []byte("b-data"), imgB.Content)
+}

--- a/internal/caches/ttl.go
+++ b/internal/caches/ttl.go
@@ -100,6 +100,11 @@ func (c *TTLCache) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) 
 	return c.Cache.Save(ctx, t, img)
 }
 
+// An entry past its TTL still occupies space, so it's removed rather than treated as already gone.
+func (c *TTLCache) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	return c.Cache.Remove(ctx, t)
+}
+
 func (c *TTLCache) Close(ctx context.Context) error {
 	return lifecycle.CloseIfCloser(ctx, c.Cache)
 }

--- a/internal/caches/ttl_test.go
+++ b/internal/caches/ttl_test.go
@@ -50,6 +50,13 @@ func (m *memCache) Save(_ context.Context, t pkg.TileRequest, img *pkg.Image) er
 	return nil
 }
 
+func (m *memCache) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	_, ok := m.entries[t.String()]
+	delete(m.entries, t.String())
+
+	return ok, nil
+}
+
 func testTileRequest() pkg.TileRequest {
 	return pkg.TileRequest{LayerName: "layer", Z: 1, X: 2, Y: 3}
 }
@@ -127,6 +134,9 @@ func (erroringCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, e
 func (erroringCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
 	return errIntentional
 }
+func (erroringCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, errIntentional
+}
 
 var errIntentional = errors.New("intentional test error")
 
@@ -154,6 +164,7 @@ type closerCache struct {
 
 func (closerCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) { return nil, nil }
 func (closerCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error   { return nil }
+func (closerCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error)       { return false, nil }
 func (c closerCache) Close(_ context.Context) error {
 	c.closeFn()
 	return nil
@@ -200,4 +211,19 @@ func Test_TTLRegistration_RegisteredUnderName(t *testing.T) {
 	reg, ok := cache.RegisteredCache("ttl")
 	require.True(t, ok)
 	require.Equal(t, "ttl", reg.Name())
+}
+
+func Test_TTLCache_RemoveForwardsToInner(t *testing.T) {
+	inner := newMemCache()
+	c := NewTTLCache(inner, time.Hour)
+	req := testTileRequest()
+
+	require.NoError(t, c.Save(context.Background(), req, &pkg.Image{Content: []byte("x")}))
+	removed, err := c.Remove(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	img, err := c.Lookup(context.Background(), req)
+	require.NoError(t, err)
+	require.Nil(t, img)
 }

--- a/internal/caches/utility_test.go
+++ b/internal/caches/utility_test.go
@@ -156,6 +156,25 @@ func validateSaveAndLookup(t *testing.T, c cache.Cache) {
 	validateLookup(t, c, tile, &img)
 }
 
+// validateRemove covers the whole contract: a removed tile is gone, and removing one that was
+// never cached is not an error.
+func validateRemove(t *testing.T, c cache.Cache) {
+	tile := makeReq(rand.Intn(10000))
+	img := makeImg(rand.Intn(100))
+
+	require.NoError(t, c.Save(context.Background(), tile, &img))
+	validateLookup(t, c, tile, &img)
+
+	removed, err := c.Remove(context.Background(), tile)
+	require.NoError(t, err, "Cache remove returned an error")
+	require.True(t, removed, "Cache remove didn't report removing a cached tile")
+	validateNoLookup(t, c, tile)
+
+	removed, err = c.Remove(context.Background(), tile)
+	require.NoError(t, err, "Removing an uncached tile returned an error")
+	require.False(t, removed, "Cache remove reported removing a tile that wasn't cached")
+}
+
 func validateLookup(t *testing.T, c cache.Cache, tile pkg.TileRequest, expected *pkg.Image) {
 	img2, err := c.Lookup(context.Background(), tile)
 	require.NoError(t, err, "Cache lookup returned an error")

--- a/pkg/entities/cache/cache.go
+++ b/pkg/entities/cache/cache.go
@@ -27,6 +27,8 @@ import (
 type Cache interface {
 	Lookup(ctx context.Context, t pkg.TileRequest) (*pkg.Image, error)
 	Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) error
+	// The bool reports whether an entry was actually there; a miss is not an error.
+	Remove(ctx context.Context, t pkg.TileRequest) (bool, error)
 }
 
 // CacheDeps carries everything a cache is given at construction. New dependencies are added as fields so

--- a/pkg/entities/cache/cache_registry_test.go
+++ b/pkg/entities/cache/cache_registry_test.go
@@ -28,6 +28,7 @@ type stubCache struct{}
 
 func (stubCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) { return nil, nil }
 func (stubCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error   { return nil }
+func (stubCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error)       { return false, nil }
 
 type stubCacheRegistration struct {
 	name string

--- a/pkg/entities/cache/wrapper.go
+++ b/pkg/entities/cache/wrapper.go
@@ -48,6 +48,20 @@ func (w CacheWrapper) Close(ctx context.Context) error {
 	return lifecycle.CloseIfCloser(ctx, w.Cache)
 }
 
+func (w CacheWrapper) Remove(ctx context.Context, t pkg.TileRequest) (bool, error) {
+	newCtx, span := pkg.MakeChildSpan(ctx, &t, "Cache", w.Name, "Remove")
+	defer span.End()
+
+	removed, err := w.Cache.Remove(newCtx, t)
+
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "Error from "+w.Name)
+	}
+
+	return removed, err
+}
+
 func (w CacheWrapper) Save(ctx context.Context, t pkg.TileRequest, img *pkg.Image) error {
 	newCtx, span := pkg.MakeChildSpan(ctx, &t, "Cache", w.Name, "Save")
 	defer span.End()

--- a/pkg/entities/cache/wrapper_test.go
+++ b/pkg/entities/cache/wrapper_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Michael Davis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Michad/tilegroxy/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingCache struct {
+	removed []pkg.TileRequest
+	err     error
+	present bool
+}
+
+func (c *recordingCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) {
+	return nil, nil
+}
+
+func (c *recordingCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
+	return nil
+}
+
+func (c *recordingCache) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	c.removed = append(c.removed, t)
+	return c.present, c.err
+}
+
+func Test_CacheWrapper_RemoveForwardsToWrapped(t *testing.T) {
+	inner := &recordingCache{present: true}
+	w := CacheWrapper{Name: "stub", Cache: inner}
+	req := pkg.TileRequest{LayerName: "layer", Z: 1, X: 2, Y: 3}
+
+	removed, err := w.Remove(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, removed)
+	require.Equal(t, []pkg.TileRequest{req}, inner.removed)
+}
+
+func Test_CacheWrapper_RemovePropagatesError(t *testing.T) {
+	expected := errors.New("intentional test error")
+	w := CacheWrapper{Name: "stub", Cache: &recordingCache{err: expected}}
+
+	removed, err := w.Remove(context.Background(), pkg.TileRequest{LayerName: "layer", Z: 1, X: 2, Y: 3})
+	require.ErrorIs(t, err, expected)
+	require.False(t, removed)
+}

--- a/pkg/entities/layer/layergroup.go
+++ b/pkg/entities/layer/layergroup.go
@@ -449,6 +449,30 @@ func (lg *LayerGroup) Close(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+// Resolves the layer and cacheversion like RenderTile so it removes the entry a render would read.
+func (lg *LayerGroup) PurgeTile(ctx context.Context, tileRequest pkg.TileRequest) (bool, error) {
+	l := lg.FindLayer(ctx, tileRequest.LayerName)
+
+	if l == nil {
+		return false, pkg.UnauthorizedError{Message: "Layer " + tileRequest.LayerName + " does not exist"}
+	}
+
+	if err := l.CheckZoomBounds(tileRequest); err != nil {
+		return false, err
+	}
+
+	if l.Config.SkipCache {
+		return false, nil
+	}
+
+	cacheTileRequest := tileRequest
+	if l.Config.CacheVersion != "" {
+		cacheTileRequest = pkg.TileRequest{LayerName: l.Config.CacheVersion + tileRequest.LayerName, X: tileRequest.X, Y: tileRequest.Y, Z: tileRequest.Z}
+	}
+
+	return l.Cache.Remove(ctx, cacheTileRequest)
+}
+
 func (lg *LayerGroup) RenderTileNoCache(ctx context.Context, tileRequest pkg.TileRequest) (*pkg.Image, error) {
 	var err error
 

--- a/pkg/entities/layer/layergroup_cachewrite_test.go
+++ b/pkg/entities/layer/layergroup_cachewrite_test.go
@@ -63,6 +63,10 @@ func (c *alwaysMissCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Imag
 	return nil
 }
 
+func (c *alwaysMissCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, nil
+}
+
 // RenderTile is exported API, so a library consumer can call it with a plain stdlib context
 // rather than one from pkg.NewRequestContext. A context carrying no restriction info has to be
 // treated as unrestricted instead of dereferencing the nil pointers that come back.
@@ -122,6 +126,10 @@ func (c *blockingCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image)
 	return nil
 }
 
+func (c *blockingCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, nil
+}
+
 // Without a bound, a slow cache backend plus sustained misses accumulates goroutines and the
 // images they pin. The tiles are distinct so singleflight doesn't collapse the misses.
 func Test_LayerGroup_RenderTile_BoundsConcurrentCacheWrites(t *testing.T) {
@@ -171,6 +179,10 @@ func (alwaysHitCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, 
 
 func (alwaysHitCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
 	return nil
+}
+
+func (alwaysHitCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, nil
 }
 
 // A zoom limit added after a tile was cached (or a tile seeded outside the layer's configured
@@ -324,6 +336,10 @@ func (panicOnSaveCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image
 
 func (panicOnSaveCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
 	panic("simulated panic from a buggy Cache.Save implementation")
+}
+
+func (panicOnSaveCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error) {
+	return false, nil
 }
 
 // writeCache runs on its own goroutine after a cache miss, so an unrecovered panic from a

--- a/pkg/entities/layer/layergroup_purge_test.go
+++ b/pkg/entities/layer/layergroup_purge_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Michael Davis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Michad/tilegroxy/pkg"
+	"github.com/Michad/tilegroxy/pkg/config"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// removeRecordingCache records what PurgeTile asks it to delete.
+type removeRecordingCache struct {
+	removed []pkg.TileRequest
+	present bool
+}
+
+func (c *removeRecordingCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) {
+	return nil, nil
+}
+
+func (c *removeRecordingCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error {
+	return nil
+}
+
+func (c *removeRecordingCache) Remove(_ context.Context, t pkg.TileRequest) (bool, error) {
+	c.removed = append(c.removed, t)
+	return c.present, nil
+}
+
+func purgeTestLayerGroup(t *testing.T, c *removeRecordingCache, cfg config.LayerConfig) *LayerGroup {
+	t.Helper()
+
+	l := &Layer{
+		ID:       "test",
+		Pattern:  []layerSegment{{value: "test", placeholder: false}},
+		Provider: &slowGenerateProvider{delay: 0},
+		Cache:    c,
+		Config:   cfg,
+	}
+	l.tileAllCounter = noop.Int64Counter{}
+	l.tileAuthCounter = noop.Int64Counter{}
+	l.tileErrorCounter = noop.Int64Counter{}
+	l.tileSuccessCounter = noop.Int64Counter{}
+
+	return &LayerGroup{
+		layers:           []*Layer{l},
+		DefaultCache:     c,
+		cacheHitCounter:  noop.Int64Counter{},
+		cacheMissCounter: noop.Int64Counter{},
+	}
+}
+
+func Test_LayerGroup_PurgeTile_RemovesFromCache(t *testing.T) {
+	c := &removeRecordingCache{present: true}
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{})
+
+	req := pkg.TileRequest{LayerName: "test", Z: 3, X: 1, Y: 2}
+	removed, err := lg.PurgeTile(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	require.Equal(t, []pkg.TileRequest{req}, c.removed)
+}
+
+// The count a purge reports comes from the cache, so an uncached tile has to come back false.
+func Test_LayerGroup_PurgeTile_ReportsUncachedTile(t *testing.T) {
+	c := &removeRecordingCache{}
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{})
+
+	removed, err := lg.PurgeTile(context.Background(), pkg.TileRequest{LayerName: "test", Z: 3, X: 1, Y: 2})
+	require.NoError(t, err)
+	require.False(t, removed)
+}
+
+// A purge has to target the same key a render would read, which cacheversion prefixes.
+func Test_LayerGroup_PurgeTile_AppliesCacheVersion(t *testing.T) {
+	c := &removeRecordingCache{}
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{CacheVersion: "v2"})
+
+	_, err := lg.PurgeTile(context.Background(), pkg.TileRequest{LayerName: "test", Z: 3, X: 1, Y: 2})
+	require.NoError(t, err)
+
+	require.Len(t, c.removed, 1)
+	require.Equal(t, "v2test", c.removed[0].LayerName)
+}
+
+func Test_LayerGroup_PurgeTile_SkipCacheLayerIsNoop(t *testing.T) {
+	c := &removeRecordingCache{}
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{SkipCache: true})
+
+	removed, err := lg.PurgeTile(context.Background(), pkg.TileRequest{LayerName: "test", Z: 3, X: 1, Y: 2})
+	require.NoError(t, err)
+	require.False(t, removed)
+	require.Empty(t, c.removed)
+}
+
+func Test_LayerGroup_PurgeTile_UnknownLayerErrors(t *testing.T) {
+	c := &removeRecordingCache{}
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{})
+
+	_, err := lg.PurgeTile(context.Background(), pkg.TileRequest{LayerName: "missing", Z: 3, X: 1, Y: 2})
+
+	require.Error(t, err)
+	require.Empty(t, c.removed)
+}
+
+func Test_LayerGroup_PurgeTile_OutOfZoomRangeErrors(t *testing.T) {
+	c := &removeRecordingCache{}
+	minZoom := 4
+	lg := purgeTestLayerGroup(t, c, config.LayerConfig{MinZoom: &minZoom})
+
+	_, err := lg.PurgeTile(context.Background(), pkg.TileRequest{LayerName: "test", Z: 1, X: 0, Y: 0})
+
+	var rangeErr pkg.RangeError
+	require.ErrorAs(t, err, &rangeErr)
+	require.Empty(t, c.removed)
+}

--- a/pkg/entry/seed.go
+++ b/pkg/entry/seed.go
@@ -47,6 +47,7 @@ type SeedOptions struct {
 	ProgressFile string
 	CacheName    string
 	MaxFailures  uint64
+	Purge        bool
 }
 
 func Seed(cfg *config.Config, opts SeedOptions, out io.Writer) error {
@@ -109,7 +110,8 @@ func Seed(cfg *config.Config, opts SeedOptions, out io.Writer) error {
 		maxFailures = seedJob.Count() - start
 	}
 
-	if err = seedTiles(seedJob, opts, out, layerGroup, numThread, progress, start, maxFailures); err != nil {
+	purged, err := seedTiles(seedJob, opts, out, layerGroup, numThread, progress, start, maxFailures)
+	if err != nil {
 		return err
 	}
 
@@ -119,8 +121,12 @@ func Seed(cfg *config.Config, opts SeedOptions, out io.Writer) error {
 		}
 	}
 
+	if opts.Purge {
+		fmt.Fprintf(out, "Removed %v of %v tiles\n", purged, seedJob.Count()-start)
+	}
+
 	if opts.Verbose {
-		fmt.Fprintf(out, "Completed seeding")
+		fmt.Fprintf(out, "Completed %v", pkg.Ternary(opts.Purge, "purging", "seeding"))
 	}
 
 	return nil
@@ -167,6 +173,15 @@ func restrictToCacheTier(rawConfig map[string]interface{}, name string) (map[str
 func checkSeedSize(seedJob *seed.SeedJob, opts SeedOptions, out io.Writer) error {
 	count := seedJob.Count()
 
+	// A purge makes no upstream requests, so the tile count only needs to stay addressable.
+	if opts.Purge {
+		if count >= math.MaxInt32 {
+			return fmt.Errorf("too many tiles to purge (%v > %v)", count, math.MaxInt32)
+		}
+
+		return nil
+	}
+
 	if count <= warnCount || opts.Force && count < math.MaxInt32 {
 		if opts.Verbose && count > warnCount {
 			fmt.Fprintf(out, "Seeding %v tiles\n", count)
@@ -206,7 +221,7 @@ func resolveProgress(currentSeedJob *seed.SeedJob, opts SeedOptions, out io.Writ
 	return existing, existing.Position, nil
 }
 
-func seedTiles(seedJob *seed.SeedJob, opts SeedOptions, out io.Writer, layerGroup *layer.LayerGroup, numThread uint16, progress *seed.Progress, start uint64, maxFailures uint64) error {
+func seedTiles(seedJob *seed.SeedJob, opts SeedOptions, out io.Writer, layerGroup *layer.LayerGroup, numThread uint16, progress *seed.Progress, start uint64, maxFailures uint64) (uint64, error) {
 	tiles := make(chan indexedTile)
 	done := make(chan uint64, numThread)
 
@@ -223,6 +238,7 @@ func seedTiles(seedJob *seed.SeedJob, opts SeedOptions, out io.Writer, layerGrou
 
 	giveUp := make(chan struct{})
 	failures := &atomic.Uint64{}
+	purged := &atomic.Uint64{}
 
 	onFailure := func() {
 		if failures.Add(1) >= maxFailures {
@@ -233,7 +249,7 @@ func seedTiles(seedJob *seed.SeedJob, opts SeedOptions, out io.Writer, layerGrou
 	for t := range int(numThread) {
 		wg.Add(1)
 
-		go seedThread(&wg, opts, out, layerGroup, t, tiles, done, errs, onFailure)
+		go seedThread(&wg, opts, out, layerGroup, t, tiles, done, errs, onFailure, purged)
 	}
 
 	go func() {
@@ -282,14 +298,14 @@ feed:
 	}
 
 	if failed := failures.Load(); failed > 0 && failed >= maxFailures {
-		threadErrs = append(threadErrs, fmt.Errorf("%w: %v of %v tiles failed to render", ErrTooManyFailures, failed, seedJob.Count()-start))
+		threadErrs = append(threadErrs, fmt.Errorf("%w: %v of %v tiles failed to %v", ErrTooManyFailures, failed, seedJob.Count()-start, pkg.Ternary(opts.Purge, "purge", "render")))
 	}
 
 	if len(threadErrs) > 0 {
-		return errors.Join(threadErrs...)
+		return purged.Load(), errors.Join(threadErrs...)
 	}
 
-	return nil
+	return purged.Load(), nil
 }
 
 type indexedTile struct {
@@ -341,7 +357,7 @@ func trackProgress(opts SeedOptions, progress *seed.Progress, start uint64, done
 	return saveErr
 }
 
-func seedThread(wg *sync.WaitGroup, opts SeedOptions, out io.Writer, layerGroup *layer.LayerGroup, t int, tiles <-chan indexedTile, done chan<- uint64, errs chan<- error, onFailure func()) {
+func seedThread(wg *sync.WaitGroup, opts SeedOptions, out io.Writer, layerGroup *layer.LayerGroup, t int, tiles <-chan indexedTile, done chan<- uint64, errs chan<- error, onFailure func(), purged *atomic.Uint64) {
 	defer wg.Done()
 	defer func() {
 		if r := recover(); r != nil {
@@ -357,7 +373,18 @@ func seedThread(wg *sync.WaitGroup, opts SeedOptions, out io.Writer, layerGroup 
 	ctx := pkg.BackgroundContext()
 
 	for tile := range tiles {
-		_, tileErr := layerGroup.RenderTile(ctx, tile.request)
+		var tileErr error
+
+		removed := false
+
+		if opts.Purge {
+			removed, tileErr = layerGroup.PurgeTile(ctx, tile.request)
+			if removed {
+				purged.Add(1)
+			}
+		} else {
+			_, tileErr = layerGroup.RenderTile(ctx, tile.request)
+		}
 
 		if tileErr != nil {
 			onFailure()
@@ -365,10 +392,14 @@ func seedThread(wg *sync.WaitGroup, opts SeedOptions, out io.Writer, layerGroup 
 
 		if opts.Verbose {
 			var status string
-			if tileErr == nil {
-				status = "OK"
-			} else {
+
+			switch {
+			case tileErr != nil:
 				status = tileErr.Error()
+			case opts.Purge && !removed:
+				status = "Not cached"
+			default:
+				status = "OK"
 			}
 
 			fmt.Fprintf(out, "Thread %v - %v = %v\n", t, tile.request, status)

--- a/pkg/entry/seed_test.go
+++ b/pkg/entry/seed_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func Test_SeedThread_RecoversFromPanic(t *testing.T) {
 	close(tiles)
 
 	require.NotPanics(t, func() {
-		seedThread(&wg, SeedOptions{Verbose: true}, &out, lg, 0, tiles, done, errs, func() {})
+		seedThread(&wg, SeedOptions{Verbose: true}, &out, lg, 0, tiles, done, errs, func() {}, &atomic.Uint64{})
 	})
 
 	wg.Wait()
@@ -673,4 +674,165 @@ func Test_Seed_MaxFailuresAboveTileCount(t *testing.T) {
 		NumThread:   1,
 		MaxFailures: 5,
 	}, &out))
+}
+
+// A purge deletes what a seed wrote, over the same layer/bounds/zoom parameters.
+func Test_Seed_PurgeRemovesCachedTiles(t *testing.T) {
+	cfg := seedTestConfig(t)
+	dir := t.TempDir()
+	cfg.Cache = map[string]interface{}{"name": "disk", "path": dir}
+
+	opts := SeedOptions{
+		Zoom:      []uint{0, 1},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, Seed(&cfg, opts, &out))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "seed wrote nothing to purge")
+
+	purgeOpts := opts
+	purgeOpts.Purge = true
+
+	out.Reset()
+	require.NoError(t, Seed(&cfg, purgeOpts, &out))
+
+	entries, err = os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+
+	// Zoom 0 and 1 over the whole world is 1 + 4 tiles, all of them seeded above.
+	assert.Contains(t, out.String(), "Removed 5 of 5 tiles")
+}
+
+// The reported count is what tells an operator whether a purge actually found anything, so tiles
+// that were never cached must not be counted.
+func Test_Seed_PurgeReportsOnlyTilesThatWereCached(t *testing.T) {
+	cfg := seedTestConfig(t)
+	cfg.Cache = map[string]interface{}{"name": "disk", "path": t.TempDir()}
+
+	var out bytes.Buffer
+	require.NoError(t, Seed(&cfg, SeedOptions{
+		Zoom:      []uint{0, 1},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+		Purge:     true,
+	}, &out))
+
+	assert.Contains(t, out.String(), "Removed 0 of 5 tiles")
+}
+
+// A purge covering more than was seeded reports only what it found, not the whole range.
+func Test_Seed_PurgeReportsPartialCount(t *testing.T) {
+	cfg := seedTestConfig(t)
+	dir := t.TempDir()
+	cfg.Cache = map[string]interface{}{"name": "disk", "path": dir}
+
+	var out bytes.Buffer
+	require.NoError(t, Seed(&cfg, SeedOptions{
+		Zoom:      []uint{0},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+	}, &out))
+
+	out.Reset()
+	require.NoError(t, Seed(&cfg, SeedOptions{
+		Zoom:      []uint{0, 1},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+		Purge:     true,
+	}, &out))
+
+	assert.Contains(t, out.String(), "Removed 1 of 5 tiles")
+}
+
+// The point of a purge is to reclaim space, so it must not repopulate what it deletes.
+func Test_Seed_PurgeDoesNotCallProvider(t *testing.T) {
+	cfg := seedTestConfig(t)
+	cfg.Cache = map[string]interface{}{"name": "disk", "path": t.TempDir()}
+
+	var out bytes.Buffer
+	require.NoError(t, Seed(&cfg, SeedOptions{
+		Zoom:      []uint{0, 1},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+		Purge:     true,
+	}, &out))
+
+	_, rendered := seedTestCounter.snapshot()
+	assert.Empty(t, rendered)
+}
+
+// --force guards against hammering an upstream provider, which a purge never does.
+func Test_Seed_PurgeSkipsForceThreshold(t *testing.T) {
+	e, err := seed.NewSeedJob("counts", pkg.WorldBounds(), []uint{10})
+	require.NoError(t, err)
+	require.Greater(t, e.Count(), uint64(warnCount))
+
+	var out bytes.Buffer
+
+	require.NoError(t, checkSeedSize(e, SeedOptions{LayerName: "counts", Purge: true}, &out))
+	require.ErrorContains(t, checkSeedSize(e, SeedOptions{LayerName: "counts"}, &out), "--force")
+}
+
+// A purge restricted to one tier leaves the others alone, the same way seeding does.
+func Test_Seed_PurgeCacheNameTargetsOneTier(t *testing.T) {
+	cfg := seedTestConfig(t)
+	purged := t.TempDir()
+	kept := t.TempDir()
+	cfg.Cache = map[string]interface{}{
+		"name": "multi",
+		"tiers": []map[string]interface{}{
+			{"name": "disk", "path": purged},
+			{"name": "disk", "path": kept},
+		},
+	}
+
+	opts := SeedOptions{
+		Zoom:      []uint{0},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "counts",
+		NumThread: 1,
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, Seed(&cfg, opts, &out))
+
+	purgeOpts := opts
+	purgeOpts.Purge = true
+	purgeOpts.CacheName = "disk"
+
+	require.NoError(t, Seed(&cfg, purgeOpts, &out))
+
+	purgedEntries, err := os.ReadDir(purged)
+	require.NoError(t, err)
+	require.Empty(t, purgedEntries)
+
+	keptEntries, err := os.ReadDir(kept)
+	require.NoError(t, err)
+	require.NotEmpty(t, keptEntries)
+}
+
+func Test_Seed_PurgeInvalidLayer(t *testing.T) {
+	cfg := seedTestConfig(t)
+
+	var out bytes.Buffer
+	err := Seed(&cfg, SeedOptions{
+		Zoom:      []uint{0},
+		Bounds:    pkg.WorldBounds(),
+		LayerName: "nope",
+		NumThread: 1,
+		Purge:     true,
+	}, &out)
+
+	require.ErrorContains(t, err, "invalid layer")
 }

--- a/pkg/entry/serve_test.go
+++ b/pkg/entry/serve_test.go
@@ -41,6 +41,7 @@ type spyCache struct {
 
 func (spyCache) Lookup(_ context.Context, _ pkg.TileRequest) (*pkg.Image, error) { return nil, nil }
 func (spyCache) Save(_ context.Context, _ pkg.TileRequest, _ *pkg.Image) error   { return nil }
+func (spyCache) Remove(_ context.Context, _ pkg.TileRequest) (bool, error)       { return false, nil }
 func (c spyCache) Close(_ context.Context) error {
 	c.closes.Add(1)
 	return nil


### PR DESCRIPTION
Breaking: cache interface has additional method for removing tiles - mandatory change if adding custom cache via lib